### PR TITLE
add javase1.6 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,15 @@
 		</dependency>
 	</dependencies>
 	<build>
-		<plugins>
+		<plugins>  
+			<plugin>    
+				<groupId>org.apache.maven.plugins</groupId>    
+				<artifactId>maven-compiler-plugin</artifactId>    
+				<configuration>    
+					<source>1.6</source>    
+					<target>1.6</target>    
+				</configuration>    
+			</plugin> 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Default jre dependency is javase1.5 where use maven3 eclipse plugin.The @Override annotated method overrides to the interface directly will display the error. So use maven-compiler-plugin 1.6 to correct