### PR TITLE
Redis注册中心多实例问题,Redis注册中心destroy方法永远不会被执行问题

### DIFF
--- a/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
@@ -18,16 +18,16 @@ package com.alibaba.dubbo.registry.redis;
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.registry.Registry;
 import com.alibaba.dubbo.registry.RegistryFactory;
+import com.alibaba.dubbo.registry.support.AbstractRegistryFactory;
 
 /**
  * RedisRegistryFactory
  * 
  * @author william.liangf
  */
-public class RedisRegistryFactory implements RegistryFactory {
+public class RedisRegistryFactory extends AbstractRegistryFactory {
 
-    public Registry getRegistry(URL url) {
+    protected Registry createRegistry(URL url) {
         return new RedisRegistry(url);
     }
-
 }


### PR DESCRIPTION
1.RedisRegistryFactory工厂没有继承 AbstractRegistryFactory，导致RedisRegistry是多实例。

2.ProtocolConfig.destroyAll()方法执行的AbstractRegistryFactory缓存中的注册中心实例，
因为没有继承所以缓存中没有实例对象，所以RedisRegistry的destroy方法永远不会被执行。