### PR TITLE
Fix building for 2.4.11

### DIFF
--- a/dubbo-admin/pom.xml
+++ b/dubbo-admin/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>dubbo-parent</artifactId>
-		<version>2.4.10</version>
+		<version>2.4.11</version>
 	</parent>
 	<artifactId>dubbo-admin</artifactId>
 	<packaging>war</packaging>

--- a/dubbo-demo/dubbo-demo-api/pom.xml
+++ b/dubbo-demo/dubbo-demo-api/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>dubbo-demo</artifactId>
-		<version>2.4.10</version>
+		<version>2.4.11</version>
 	</parent>
 	<artifactId>dubbo-demo-api</artifactId>
 	<packaging>jar</packaging>

--- a/dubbo-demo/dubbo-demo-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-consumer/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>dubbo-demo</artifactId>
-		<version>2.4.10</version>
+		<version>2.4.11</version>
 	</parent>
 	<artifactId>dubbo-demo-consumer</artifactId>
 	<packaging>jar</packaging>

--- a/dubbo-demo/dubbo-demo-consumer/src/main/assembly/conf/dubbo.properties
+++ b/dubbo-demo/dubbo-demo-consumer/src/main/assembly/conf/dubbo.properties
@@ -16,8 +16,8 @@
 dubbo.container=log4j,spring
 dubbo.application.name=demo-consumer
 dubbo.application.owner=
-dubbo.registry.address=multicast://224.5.6.7:1234
-#dubbo.registry.address=zookeeper://127.0.0.1:2181
+#dubbo.registry.address=multicast://224.5.6.7:1234
+dubbo.registry.address=zookeeper://127.0.0.1:2181
 #dubbo.registry.address=redis://127.0.0.1:6379
 #dubbo.registry.address=dubbo://127.0.0.1:9090
 dubbo.monitor.protocol=registry

--- a/dubbo-demo/dubbo-demo-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-provider/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>dubbo-demo</artifactId>
-		<version>2.4.10</version>
+		<version>2.4.11</version>
 	</parent>
 	<artifactId>dubbo-demo-provider</artifactId>
 	<packaging>jar</packaging>

--- a/dubbo-demo/dubbo-demo-provider/src/main/assembly/conf/dubbo.properties
+++ b/dubbo-demo/dubbo-demo-provider/src/main/assembly/conf/dubbo.properties
@@ -16,8 +16,8 @@
 dubbo.container=log4j,spring
 dubbo.application.name=demo-provider
 dubbo.application.owner=
-dubbo.registry.address=multicast://224.5.6.7:1234
-#dubbo.registry.address=zookeeper://127.0.0.1:2181
+#dubbo.registry.address=multicast://224.5.6.7:1234
+dubbo.registry.address=zookeeper://127.0.0.1:2181
 #dubbo.registry.address=redis://127.0.0.1:6379
 #dubbo.registry.address=dubbo://127.0.0.1:9090
 dubbo.monitor.protocol=registry

--- a/dubbo-demo/pom.xml
+++ b/dubbo-demo/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>dubbo-parent</artifactId>
-		<version>2.4.10</version>
+		<version>2.4.11</version>
 	</parent>
 	<artifactId>dubbo-demo</artifactId>
 	<packaging>pom</packaging>

--- a/dubbo-simple/dubbo-monitor-simple/pom.xml
+++ b/dubbo-simple/dubbo-monitor-simple/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>dubbo-simple</artifactId>
-		<version>2.4.10</version>
+		<version>2.4.11</version>
 	</parent>
 	<artifactId>dubbo-monitor-simple</artifactId>
 	<packaging>jar</packaging>

--- a/dubbo-simple/dubbo-monitor-simple/src/main/assembly/conf/dubbo.properties
+++ b/dubbo-simple/dubbo-monitor-simple/src/main/assembly/conf/dubbo.properties
@@ -16,8 +16,8 @@
 dubbo.container=log4j,spring,registry,jetty
 dubbo.application.name=simple-monitor
 dubbo.application.owner=
-dubbo.registry.address=multicast://224.5.6.7:1234
-#dubbo.registry.address=zookeeper://127.0.0.1:2181
+#dubbo.registry.address=multicast://224.5.6.7:1234
+dubbo.registry.address=zookeeper://127.0.0.1:2181
 #dubbo.registry.address=redis://127.0.0.1:6379
 #dubbo.registry.address=dubbo://127.0.0.1:9090
 dubbo.protocol.port=7070

--- a/dubbo-simple/dubbo-registry-simple/pom.xml
+++ b/dubbo-simple/dubbo-registry-simple/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>dubbo-simple</artifactId>
-		<version>2.4.10</version>
+		<version>2.4.11</version>
 	</parent>
 	<artifactId>dubbo-registry-simple</artifactId>
 	<packaging>jar</packaging>

--- a/dubbo-simple/pom.xml
+++ b/dubbo-simple/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>com.alibaba</groupId>
 		<artifactId>dubbo-parent</artifactId>
-		<version>2.4.10</version>
+		<version>2.4.11</version>
 	</parent>
 	<artifactId>dubbo-simple</artifactId>
 	<packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
 		<module>dubbo-monitor</module>
 		<module>dubbo-config</module>
 		<module>dubbo</module>
+		<module>dubbo-admin</module>
+		<module>dubbo-demo</module>
+		<module>dubbo-simple</module>
 	</modules>
 	<profiles>
 		<profile>
@@ -88,11 +91,11 @@
 		<grizzly_version>2.1.4</grizzly_version>
 		<httpclient_version>4.1.2</httpclient_version>
 		<hessian_lite_version>3.2.1-fixed-2</hessian_lite_version>
-		<xstream_version>1.4.1</xstream_version>
-		<fastjson_version>1.1.8</fastjson_version>
+		<xstream_version>1.4.8</xstream_version>
+		<fastjson_version>1.2.4</fastjson_version>
 		<bsf_version>3.1</bsf_version>
 		<sorcerer_version>0.8</sorcerer_version>
-		<zookeeper_version>3.3.3</zookeeper_version>
+		<zookeeper_version>3.4.6</zookeeper_version>
 		<zkclient_version>0.1</zkclient_version>
 		<curator_version>1.1.10</curator_version>
 		<jedis_version>2.1.0</jedis_version>


### PR DESCRIPTION
Update dependencies:
  xstream:   1.4.1 => 1.4.8
  fastjson:  1.1.8 => 1.2.4
  zookeeper: 3.3.3 => 3.4.6