### PR TITLE
Wrapper类在处理Json转换的时候无法处理Boolean 类型字段 isXX方法只匹配了 boolean类型

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/json/GenericJSONConverter.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/json/GenericJSONConverter.java
@@ -116,7 +116,8 @@ public class GenericJSONConverter implements JSONConverter
 				if ((obj instanceof Throwable) && (
 						"localizedMessage".equals(pn) 
 						|| "cause".equals(pn) 
-						|| "stackTrace".equals(pn))) {
+						|| "stackTrace".equals(pn)
+				        || "suppressed".equals(pn))) {
 					continue;
 				}
 				

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/ReflectUtils.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/ReflectUtils.java
@@ -115,7 +115,7 @@ public final class ReflectUtils {
 
 	public static final Pattern SETTER_METHOD_DESC_PATTERN = Pattern.compile("set([A-Z][_a-zA-Z0-9]*)\\((" + DESC_REGEX + ")\\)V");
 
-	public static final Pattern IS_HAS_CAN_METHOD_DESC_PATTERN = Pattern.compile("(?:is|has|can)([A-Z][_a-zA-Z0-9]*)\\(\\)Z");
+	public static final Pattern IS_HAS_CAN_METHOD_DESC_PATTERN = Pattern.compile("(?:is|has|can)([A-Z][_a-zA-Z0-9]*)\\(\\)(" + DESC_REGEX + ")");
 	
 	private static final ConcurrentMap<String, Class<?>>  DESC_CLASS_CACHE = new ConcurrentHashMap<String, Class<?>>();
     

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/json/JSONTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/json/JSONTest.java
@@ -190,6 +190,10 @@ public class JSONTest extends TestCase
 	{
 		private String name, displayName = "钱磊";
 
+		private boolean ok;
+
+		private Boolean ok2;
+
 		public int[] array;
 
 		public boolean $b;
@@ -212,6 +216,22 @@ public class JSONTest extends TestCase
 
 		public void setName(String name) {
 			this.name = name;
+		}
+
+		public boolean isOk() {
+			return ok;
+		}
+
+		public void setOk(boolean ok) {
+			this.ok = ok;
+		}
+
+		public Boolean isOk2() {
+			return ok2;
+		}
+
+		public void setOk2(Boolean ok2) {
+			this.ok2 = ok2;
 		}
 	}
 }


### PR DESCRIPTION
```java
Bean {
   private Boolean ok;
   public Boolean isOk(){...}
   public void setOk(Boolean ok){...}
}

Bean bean = new Bean();
String json = JSON.json(bean);
```
转换异常
```java
com.alibaba.dubbo.common.bytecode.NoSuchPropertyException: Not found property "ok" filed or setter method in class com.alibaba.dubbo.common.json.JSONTest$Bean.
	at com.alibaba.dubbo.common.bytecode.Wrapper1.getPropertyValue(Wrapper1.java)
	at com.alibaba.dubbo.common.json.GenericJSONConverter.writeValue(GenericJSONConverter.java:125)
	at com.alibaba.dubbo.common.json.JSON.json(JSON.java:143)
	at com.alibaba.dubbo.common.json.JSON.json(JSON.java:94)
	at com.alibaba.dubbo.common.json.JSON.json(JSON.java:86)
	at com.alibaba.dubbo.common.json.JSON.json(JSON.java:71)
	at com.alibaba.dubbo.common.json.JSONTest.testObject2Json(JSONTest.java:97)
```
