### PR TITLE
根据参数进行静态hash并不能够保证能够进行静态hash

### DIFF
--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
@@ -32,6 +32,9 @@ import com.alibaba.dubbo.rpc.Invoker;
 /**
  * ConsistentHashLoadBalance
  * 
+ * 如果你希望通过参数的值来进行hash的话，请注意以下内容：hash的凭据是参数的toString
+ * 如果能保证值相同的参数的toString的结果是一致的，才能保证能够hash到同一个provider
+ * 
  * @author william.liangf
  */
 public class ConsistentHashLoadBalance extends AbstractLoadBalance {


### PR DESCRIPTION
详情参见：
com.alibaba.dubbo.rpc.cluster.loadbalance.ConsistentHashLoadBalance.ConsistentHashSelector#select
以及
com.alibaba.dubbo.rpc.cluster.loadbalance.ConsistentHashLoadBalance.ConsistentHashSelector#toKey

这里实际上是用的toString作为值来进行hash
如果没有重写toString
实际上值相等的两个对象很可能hash的结果不一样，而达不到这个loadBalance的目的

在qq群中 @北京-黄平 首先提出这个这里应该用hashCode而不是toString
然后仔细阅读源代码之后发现
除了java基本的数据结构，其他的对象基本都不能通过参数来达到这个loadBalance的目的
