### PR TITLE
修正 telnet count 服务提供者统计不准确问题

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/ExecuteLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/ExecuteLimitFilter.java
@@ -37,20 +37,20 @@ public class ExecuteLimitFilter implements Filter {
         URL url = invoker.getUrl();
         String methodName = invocation.getMethodName();
         int max = url.getMethodParameter(methodName, Constants.EXECUTES_KEY, 0);
-        if (max > 0) {
+        if (max >= 0) {
             RpcStatus count = RpcStatus.getStatus(url, invocation.getMethodName());
             if (count.getActive() >= max) {
                 throw new RpcException("Failed to invoke method " + invocation.getMethodName() + " in provider " + url + ", cause: The service using threads greater than <dubbo:service executes=\"" + max + "\" /> limited.");
             }
         }
         long begin = System.currentTimeMillis();
-        boolean isException = false;
+        boolean succeeded = true;
         RpcStatus.beginCount(url, methodName);
         try {
             Result result = invoker.invoke(invocation);
             return result;
         } catch (Throwable t) {
-            isException = true;
+            succeeded = false;
             if(t instanceof RuntimeException) {
                 throw (RuntimeException) t;
             }
@@ -59,7 +59,7 @@ public class ExecuteLimitFilter implements Filter {
             }
         }
         finally {
-            RpcStatus.endCount(url, methodName, System.currentTimeMillis() - begin, isException);
+            RpcStatus.endCount(url, methodName, System.currentTimeMillis() - begin, succeeded);
         }
     }
 


### PR DESCRIPTION
修正了两个问题:
1. 服务提供者必须设置 `executes`  `RpcStatus` 才生效.
2. 统计服务调用成功的标记位搞反了. 统一了参数名称, 这要更好理解.
