### PR TITLE
fix English grammar error

### DIFF
--- a/README
+++ b/README
@@ -1,14 +1,14 @@
-Dubbo is a distributed service framework enpowers applications with service import/export capability with high performance RPC.
+Dubbo is a distributed service framework which enpowers applications with service import/export capability with high performance RPC.
 
 It's composed of three kernel parts:
 
-Remoting: a network communication framework provides sync-over-async and request-response messaging.
+Remoting: a network communication framework which provides sync-over-async and request-response messaging.
 
 Clustering: a remote procedure call abstraction with load-balancing/failover/clustering capabilities.
 
 Registry: a service directory framework for service registration and service event publish/subscription
 
-For more, please refer to:
+For more information, please refer to:
 
     http://dubbo.io
 


### PR DESCRIPTION
除了这个pr里的语法错误，项目名下的项目描述也需要加入`which`,即:

> Dubbo is a distributed service framework `which` empowers applications...