### PR TITLE
修正URL.java中构造函数中用于移除path开头的“/”的代码

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/URL.java
@@ -155,11 +155,11 @@ public final class URL implements Serializable {
 		this.password = password;
 		this.host = host;
 		this.port = (port < 0 ? 0 : port);
-		this.path = path;
 		// trim the beginning "/"
 		while(path != null && path.startsWith("/")) {
 		    path = path.substring(1);
 		}
+		this.path = path;
 		if (parameters == null) {
 		    parameters = new HashMap<String, String>();
 		} else {


### PR DESCRIPTION
移除path字符串开头的“/”代码没有起效，应该修改移除while这段代码或后移this.path的赋值