### PR TITLE
fix typo of method

### DIFF
--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/AbstractClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/AbstractClusterInvoker.java
@@ -212,7 +212,7 @@ public abstract class AbstractClusterInvoker<T> implements Invoker<T> {
     
     public Result invoke(final Invocation invocation) throws RpcException {
 
-        checkWheatherDestoried();
+        checkWhetherDestroyed();
 
         LoadBalance loadbalance;
         
@@ -227,7 +227,7 @@ public abstract class AbstractClusterInvoker<T> implements Invoker<T> {
         return doInvoke(invocation, invokers, loadbalance);
     }
 
-    protected void checkWheatherDestoried() {
+    protected void checkWhetherDestroyed() {
 
         if(destroyed){
             throw new RpcException("Rpc cluster invoker for " + getInterface() + " on consumer " + NetUtils.getLocalHost()

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
@@ -65,7 +65,7 @@ public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
         	//重试时，进行重新选择，避免重试时invoker列表已发生变化.
         	//注意：如果列表发生了变化，那么invoked判断会失效，因为invoker示例已经改变
         	if (i > 0) {
-        		checkWheatherDestoried();
+        		checkWhetherDestroyed();
         		copyinvokers = list(invocation);
         		//重新检查一下
         		checkInvokers(copyinvokers, invocation);


### PR DESCRIPTION
fix method name typo in AbstractClusterInvoker from "checkWheatherDestoried" to "checkWhetherDestroyed"