### PR TITLE
update zookeeper

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -132,7 +132,7 @@ Curator
   * LICENSE:
     * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
   * HOMEPAGE:
-    * https://github.com/Netflix/curator
+    * https://github.com/apache/curator
 
 JFreeChart:
 

--- a/dubbo-admin/pom.xml
+++ b/dubbo-admin/pom.xml
@@ -78,11 +78,11 @@
 			<artifactId>zookeeper</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.github.sgroschupf</groupId>
+			<groupId>com.101tec</groupId>
 			<artifactId>zkclient</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.netflix.curator</groupId>
+			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-framework</artifactId>
 		</dependency>
 		<dependency>

--- a/dubbo-demo/dubbo-demo-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-consumer/pom.xml
@@ -76,11 +76,11 @@
 			<artifactId>zookeeper</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.github.sgroschupf</groupId>
+			<groupId>com.101tec</groupId>
 			<artifactId>zkclient</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.netflix.curator</groupId>
+			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-framework</artifactId>
 		</dependency>
 		<dependency>

--- a/dubbo-demo/dubbo-demo-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-provider/pom.xml
@@ -76,11 +76,11 @@
 			<artifactId>zookeeper</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.github.sgroschupf</groupId>
+			<groupId>com.101tec</groupId>
 			<artifactId>zkclient</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.netflix.curator</groupId>
+			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-framework</artifactId>
 		</dependency>
 		<dependency>

--- a/dubbo-maven/pom.xml
+++ b/dubbo-maven/pom.xml
@@ -96,19 +96,19 @@
 		<dependency>
 			<groupId>org.apache.zookeeper</groupId>
 			<artifactId>zookeeper</artifactId>
-			<version>3.3.3</version>
+			<version>3.4.8</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.sgroschupf</groupId>
+			<groupId>com.101tec</groupId>
 			<artifactId>zkclient</artifactId>
-			<version>0.1</version>
+			<version>0.8</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.netflix.curator</groupId>
+			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-framework</artifactId>
-			<version>1.1.10</version>
+			<version>2.10.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
@@ -39,11 +39,11 @@
 		    <artifactId>zookeeper</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.github.sgroschupf</groupId>
+			<groupId>com.101tec</groupId>
 			<artifactId>zkclient</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.netflix.curator</groupId>
+			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-framework</artifactId>
 		</dependency>
 	</dependencies>

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/com/alibaba/dubbo/remoting/zookeeper/curator/CuratorZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/com/alibaba/dubbo/remoting/zookeeper/curator/CuratorZookeeperClient.java
@@ -1,6 +1,5 @@
 package com.alibaba.dubbo.remoting.zookeeper.curator;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.zookeeper.CreateMode;
@@ -12,13 +11,13 @@ import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.remoting.zookeeper.ChildListener;
 import com.alibaba.dubbo.remoting.zookeeper.StateListener;
 import com.alibaba.dubbo.remoting.zookeeper.support.AbstractZookeeperClient;
-import com.netflix.curator.framework.CuratorFramework;
-import com.netflix.curator.framework.CuratorFrameworkFactory;
-import com.netflix.curator.framework.CuratorFrameworkFactory.Builder;
-import com.netflix.curator.framework.api.CuratorWatcher;
-import com.netflix.curator.framework.state.ConnectionState;
-import com.netflix.curator.framework.state.ConnectionStateListener;
-import com.netflix.curator.retry.RetryNTimes;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.CuratorFrameworkFactory.Builder;
+import org.apache.curator.framework.api.CuratorWatcher;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryNTimes;
 
 public class CuratorZookeeperClient extends AbstractZookeeperClient<CuratorWatcher> {
 
@@ -26,31 +25,27 @@ public class CuratorZookeeperClient extends AbstractZookeeperClient<CuratorWatch
 
 	public CuratorZookeeperClient(URL url) {
 		super(url);
-		try {
-			Builder builder = CuratorFrameworkFactory.builder()
-					.connectString(url.getBackupAddress())
-			        .retryPolicy(new RetryNTimes(Integer.MAX_VALUE, 1000))  
-			        .connectionTimeoutMs(5000);
-			String authority = url.getAuthority();
-			if (authority != null && authority.length() > 0) {
-				builder = builder.authorization("digest", authority.getBytes());
-			}
-			client = builder.build();
-			client.getConnectionStateListenable().addListener(new ConnectionStateListener() {
-				public void stateChanged(CuratorFramework client, ConnectionState state) {
-					if (state == ConnectionState.LOST) {
-						CuratorZookeeperClient.this.stateChanged(StateListener.DISCONNECTED);
-					} else if (state == ConnectionState.CONNECTED) {
-						CuratorZookeeperClient.this.stateChanged(StateListener.CONNECTED);
-					} else if (state == ConnectionState.RECONNECTED) {
-						CuratorZookeeperClient.this.stateChanged(StateListener.RECONNECTED);
-					}
-				}
-			});
-			client.start();
-		} catch (IOException e) {
-			throw new IllegalStateException(e.getMessage(), e);
-		}
+		Builder builder = CuratorFrameworkFactory.builder()
+                .connectString(url.getBackupAddress())
+                .retryPolicy(new RetryNTimes(Integer.MAX_VALUE, 1000))
+                .connectionTimeoutMs(5000);
+		String authority = url.getAuthority();
+		if (authority != null && authority.length() > 0) {
+            builder = builder.authorization("digest", authority.getBytes());
+        }
+		client = builder.build();
+		client.getConnectionStateListenable().addListener(new ConnectionStateListener() {
+            public void stateChanged(CuratorFramework client, ConnectionState state) {
+                if (state == ConnectionState.LOST) {
+                    CuratorZookeeperClient.this.stateChanged(StateListener.DISCONNECTED);
+                } else if (state == ConnectionState.CONNECTED) {
+                    CuratorZookeeperClient.this.stateChanged(StateListener.CONNECTED);
+                } else if (state == ConnectionState.RECONNECTED) {
+                    CuratorZookeeperClient.this.stateChanged(StateListener.RECONNECTED);
+                }
+            }
+        });
+		client.start();
 	}
 
 	public void createPersistent(String path) {

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/com/alibaba/dubbo/remoting/zookeeper/zkclient/ZkclientZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/com/alibaba/dubbo/remoting/zookeeper/zkclient/ZkclientZookeeperClient.java
@@ -35,6 +35,12 @@ public class ZkclientZookeeperClient extends AbstractZookeeperClient<IZkChildLis
 			public void handleNewSession() throws Exception {
 				stateChanged(StateListener.RECONNECTED);
 			}
+
+			@Override
+			public void handleSessionEstablishmentError(Throwable throwable) throws Exception {
+				logger.error("Zookeeper HandleSessionEstablishmentError!", throwable);
+				throw new Exception(throwable);
+			}
 		});
 	}
 

--- a/dubbo-simple/dubbo-monitor-simple/pom.xml
+++ b/dubbo-simple/dubbo-monitor-simple/pom.xml
@@ -75,11 +75,11 @@
 			<artifactId>zookeeper</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.github.sgroschupf</groupId>
+			<groupId>com.101tec</groupId>
 			<artifactId>zkclient</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.netflix.curator</groupId>
+			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-framework</artifactId>
 		</dependency>
 		<dependency>

--- a/dubbo/pom.xml
+++ b/dubbo/pom.xml
@@ -201,11 +201,11 @@
 		    		<artifactId>zookeeper</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>com.github.sgroschupf</groupId>
+					<groupId>com.101tec</groupId>
 					<artifactId>zkclient</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>com.netflix.curator</groupId>
+					<groupId>org.apache.curator</groupId>
 					<artifactId>curator-framework</artifactId>
 				</exclusion>
 			</exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,9 @@
 		<fastjson_version>1.1.39</fastjson_version>
 		<bsf_version>3.1</bsf_version>
 		<sorcerer_version>0.8</sorcerer_version>
-		<zookeeper_version>3.3.3</zookeeper_version>
-		<zkclient_version>0.1</zkclient_version>
-		<curator_version>1.1.16</curator_version>
+		<zookeeper_version>3.4.8</zookeeper_version>
+		<zkclient_version>0.8</zkclient_version>
+		<curator_version>2.10.0</curator_version>
 		<jedis_version>2.1.0</jedis_version>
 		<xmemcached_version>1.3.6</xmemcached_version>
 		<cxf_version>2.6.1</cxf_version>
@@ -202,12 +202,12 @@
 				<version>${zookeeper_version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.github.sgroschupf</groupId>
+				<groupId>com.101tec</groupId>
 				<artifactId>zkclient</artifactId>
 				<version>${zkclient_version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.netflix.curator</groupId>
+				<groupId>org.apache.curator</groupId>
 				<artifactId>curator-framework</artifactId>
 				<version>${curator_version}</version>
 			</dependency>


### PR DESCRIPTION
update zookeeper:
zookeeper from 3.3.3 to 3.4.8;
zkclient from com.github.sgroschupf-0.1 to com.101tec-0.8 ;
curator from com.netflix.curator-1.1.16 to org.apache.curator-2.10.0;
升级zookeeper和zookeeper客户端.
由于netflix把curator贡献给apache,所以自2.0版本后curator包名有所改变.
