### PR TITLE
bugfix: make Reference annotation & Service annotation inherited

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/annotation/Reference.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/annotation/Reference.java
@@ -17,6 +17,7 @@ package com.alibaba.dubbo.config.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -30,6 +31,7 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
+@Inherited
 public @interface Reference {
 
     Class<?> interfaceClass() default void.class;

--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/annotation/Service.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/annotation/Service.java
@@ -17,6 +17,7 @@ package com.alibaba.dubbo.config.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -30,6 +31,7 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
+@Inherited
 public @interface Service {
 
     Class<?> interfaceClass() default void.class;


### PR DESCRIPTION
使用注解方式发布dubbo服务,如果使用了CGLIB代理(声明式事务&AOP)时.
因为无法从父类继承@Service注解,导致 dubbo服务也就发布不了.

解决方法,使注解可以被继承.
在注解中加入@Inherited注解,表示此注解会被子类继承.
