### PR TITLE
修改classpath路径下配置protocol协议不生效

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
@@ -192,6 +192,8 @@ public abstract class AbstractConfig implements Serializable {
                         }
                     }
                     if (value != null && value.length() > 0) {
+                        //将value统一转化为小写，以为后方是以小写的value作为键值，同时这样做也不用强求用户配置的时候使用小写
+                        value = value.toLowerCase();
                         method.invoke(config, new Object[] {convertPrimitive(method.getParameterTypes()[0], value)});
                     }
                 }

--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
@@ -531,10 +531,11 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
             setProtocol(new ProtocolConfig());
         }
         for (ProtocolConfig protocolConfig : protocols) {
+            appendProperties(protocolConfig);
+            //原有顺序错误，且此处不应将name和id固定为dubbo，这样会使classpath下的配置文件配置失效，应当在配置文件未读取到配置信息时才使用默认
             if (StringUtils.isEmpty(protocolConfig.getName())) {
                 protocolConfig.setName("dubbo");
             }
-            appendProperties(protocolConfig);
         }
     }
 


### PR DESCRIPTION
由于原有加载顺序有误导致classpath下配置文件protocol协议配置不生效，同时在读取配置文件时，将读取到的值统一置为小写，因为map中是以小写作为key值。
