### PR TITLE
修复redia注册中心缓存以及禁用服务后dubbo-admin和应用系统报错的bug

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
@@ -532,10 +532,6 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
      * @param invokers
      */
     private void destroyUnusedInvokers(Map<String, Invoker<T>> oldUrlInvokerMap, Map<String, Invoker<T>> newUrlInvokerMap) {
-        if (newUrlInvokerMap == null || newUrlInvokerMap.size() == 0) {
-            destroyAllInvokers();
-            return;
-        }
         // check deleted invoker
         List<String> deleted = null;
         if (oldUrlInvokerMap != null) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
@@ -223,12 +223,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
             }
             Map<String, Invoker<T>> newUrlInvokerMap = toInvokers(invokerUrls) ;// 将URL列表转成Invoker列表
             Map<String, List<Invoker<T>>> newMethodInvokerMap = toMethodInvokers(newUrlInvokerMap); // 换方法名映射Invoker列表
-            // state change
-            //如果计算错误，则不进行处理.
-            if (newUrlInvokerMap == null || newUrlInvokerMap.size() == 0 ){
-                logger.error(new IllegalStateException("urls to invokers error .invokerUrls.size :"+invokerUrls.size() + ", invoker.size :0. urls :"+invokerUrls.toString()));
-                return ;
-            }
+
             this.methodInvokerMap = multiGroup ? toMergeMethodInvokerMap(newMethodInvokerMap) : newMethodInvokerMap;
             this.urlInvokerMap = newUrlInvokerMap;
             try{

--- a/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistry.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistry.java
@@ -426,7 +426,8 @@ public class RedisRegistry extends FailbackRegistry {
                 urls.add(url.setProtocol(Constants.EMPTY_PROTOCOL)
                         .setAddress(Constants.ANYHOST_VALUE)
                         .setPath(toServiceName(key))
-                        .addParameter(Constants.CATEGORY_KEY, category));
+                        .addParameter(Constants.CATEGORY_KEY, category)
+						.addParameter(Constants.INTERFACE_KEY, toServiceName(key)));
             }
             result.addAll(urls);
             if (logger.isInfoEnabled()) {

--- a/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
@@ -24,9 +24,9 @@ import com.alibaba.dubbo.registry.RegistryFactory;
  * 
  * @author william.liangf
  */
-public class RedisRegistryFactory implements RegistryFactory {
+public class RedisRegistryFactory extends AbstractRegistryFactory {
 
-    public Registry getRegistry(URL url) {
+    public Registry createRegistry(URL url) {
         return new RedisRegistry(url);
     }
 

--- a/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
@@ -17,7 +17,7 @@ package com.alibaba.dubbo.registry.redis;
 
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.registry.Registry;
-import com.alibaba.dubbo.registry.RegistryFactory;
+import com.alibaba.dubbo.registry.support.AbstractRegistryFactory;
 
 /**
  * RedisRegistryFactory


### PR DESCRIPTION
1. 修复服务全部被禁用时，客户端不能处理的bug；
2. 修复redis注册中心不能缓存的bug；
3. fix服务被全部禁用时，基于redis的dubbo-admin不能处理empty协议servicename的bug。