### PR TITLE
fix #397: master is snapshot, but hessian-lite is not a snapshot

### DIFF
--- a/hessian-lite/pom.xml
+++ b/hessian-lite/pom.xml
@@ -10,6 +10,6 @@
     </parent>
     <artifactId>hessian-lite</artifactId>
     <packaging>jar</packaging>
-    <version>3.2.1-fixed-2</version>
+    <version>${hessian_lite_version}</version>
     <name>Hessian Lite(Alibaba embed version)</name>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 		<mina_version>1.1.7</mina_version>
 		<grizzly_version>2.1.4</grizzly_version>
 		<httpclient_version>4.1.2</httpclient_version>
-		<hessian_lite_version>3.2.1-fixed-2</hessian_lite_version>
+		<hessian_lite_version>3.2.1-fixed-2-SNAPSHOT</hessian_lite_version>
 		<xstream_version>1.4.1</xstream_version>
 		<fastjson_version>1.1.39</fastjson_version>
 		<bsf_version>3.1</bsf_version>


### PR DESCRIPTION
当前master是snapshot版本，而hessian-lite的版本定义不是snapshot 
思路：使用dubbo-parent中定义的properties: hessian_lite_version，统一定义hessian-lite的版本
这样在mvn deploy snapshot版本时ok

而release，统一修改即可