### PR TITLE
fix #400: SON.json(Locale) throw StackOverflowError, into the dead loop

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/json/GenericJSONConverter.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/json/GenericJSONConverter.java
@@ -24,6 +24,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -60,6 +61,10 @@ public class GenericJSONConverter implements JSONConverter
 		else if( obj instanceof JSONNode )
 		{
 			((JSONNode)obj).writeJSON(this, jb, writeClass);
+		}
+		else if( obj instanceof Locale )
+		{
+			jb.valueString(obj.toString());	//fix-JSON.json(Locale) throw StackOverflowError(into the dead loop)
 		}
 		else if( c.isEnum() )
 		{

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/json/JSONTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/json/JSONTest.java
@@ -20,15 +20,39 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import junit.framework.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class JSONTest {
+	
+	@Test
+	public void testLocale() throws Exception {
+		Locale locale = Locale.US;
+		String result = JSON.json(locale);
+		//check JSON.json(Locale) into the dead loop
+		/**
+		java.lang.StackOverflowError
+			at java.lang.StringBuilder.append(StringBuilder.java:136)
+			at sun.util.locale.provider.LocaleResources.getLocaleName(LocaleResources.java:230)
+			at java.util.Locale.getDisplayName(Locale.java:1879)
+			at java.util.Locale.getDisplayName(Locale.java:1845)
+			at com.alibaba.dubbo.common.bytecode.Wrapper1.getPropertyValue(Wrapper1.java)
+			at com.alibaba.dubbo.common.json.GenericJSONConverter.writeValue(GenericJSONConverter.java:126)
+			at com.alibaba.dubbo.common.json.GenericJSONConverter.writeValue(GenericJSONConverter.java:73)
+			at com.alibaba.dubbo.common.json.GenericJSONConverter.writeValue(GenericJSONConverter.java:130)
+			at com.alibaba.dubbo.common.json.GenericJSONConverter.writeValue(GenericJSONConverter.java:73)
+			at com.alibaba.dubbo.common.json.GenericJSONConverter.writeValue(GenericJSONConverter.java:130)
+			at com.alibaba.dubbo.common.json.GenericJSONConverter.writeValue(GenericJSONConverter.java:73)
+			at com.alibaba.dubbo.common.json.GenericJSONConverter.writeValue(GenericJSONConverter.java:130)
+		 */
+		Assert.assertEquals(result, JSON.json(locale.toString()));
+	}
+	
 	@Test
 	public void testException() throws Exception {
 		MyException e = new MyException("001", "AAAAAAAA");


### PR DESCRIPTION
在整个dubbo项目中，JSON.json只有两种用途

1. 记录日志时：pojo->json
1. CacheFilter中的cache的key生成
<pre>
Result com.alibaba.dubbo.cache.filter.CacheFilter.invoke(Invoker<?> invoker, Invocation invocation) throws RpcException
    String key = StringUtils.toArgumentString(invocation.getArguments());



	public static String toArgumentString(Object[] args) {
	    StringBuilder buf = new StringBuilder();
        for (Object arg : args) {
            if (buf.length() > 0) {
                buf.append(Constants.COMMA_SEPARATOR);
            }
            if (arg == null || ReflectUtils.isPrimitives(arg.getClass())) {
                buf.append(arg);
            } else {
                try {
                    buf.append(JSON.json(arg));
                } catch (IOException e) {
                    logger.warn(e.getMessage(), e);
                    buf.append(arg);
                }
            }
        }
        return buf.toString();
	}
</pre>

所以完全可以用string来代替，而且locale.toString()确实能代替Locale

1. Locale.toString = "${language}_${country}_${variant}"
1. str用_分割反序列化为Locale(String language, String country, String variant)