### PR TITLE
fix #402 `ps -f` is nothing, standard syntax: `ps -ef`

### DIFF
--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/dump.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/dump.sh
@@ -12,7 +12,7 @@ if [ -z "$SERVER_NAME" ]; then
 	SERVER_NAME=`hostname`
 fi
 
-PIDS=`ps -f | grep java | grep "$CONF_DIR" |awk '{print $2}'`
+PIDS=`ps -ef | grep java | grep "$CONF_DIR" |awk '{print $2}'`
 if [ -z "$PIDS" ]; then
     echo "ERROR: The $SERVER_NAME does not started!"
     exit 1


### PR DESCRIPTION
[dump.sh](https://github.com/alibaba/dubbo/blob/master/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/dump.sh#L15)

<pre>
PIDS=`ps -f | grep java | grep "$CONF_DIR" |awk '{print $2}'`
</pre>
in ubuntu 16.04 `ps -f ` is nothing
<pre>
To see every process on the system using standard syntax:
          ps -e
          ps -ef
          ps -eF
          ps -ely
</pre>