### PR TITLE
loadbalance的warmup功能失效

### DIFF
--- a/dubbo-cluster/WeightedConsistentHashLoadBalance.md
+++ b/dubbo-cluster/WeightedConsistentHashLoadBalance.md
@@ -1,0 +1,73 @@
+## 支持预热的Hash负载均衡策略
+
+### 用户手册
+
+该Feathure在是在Hash负载均衡策略的基础上增加了权重与预热的特性。
+
+使用方式很简单，只需要配置即可，很明显的负载均衡策略是在消费者一端生效，所以在消费者一端配置是能生效的。但是在Dubbo的配置体系中消费者一端的配置是会继承提供者的一些配置的。这里的“loadbalance”就会有继承效应。所以在提供者一端配置同样生效。需要明确一点的是如果配置在提供者一端对应的所有消费者都会继承配置。
+
+还有一点需要明确的是既然两端都生效就有一个优先级的问题，Dubbo中的约定是消费者一端的配置优先级要高于提供者一端的配置。以下是在spring配置文件中的配置示例：
+
+```
+#配置在消费者端
+<dubbo:reference id="demoService" loadbalance="weightedconsistenthash" interface="com.alibaba.dubbo.demo.DemoService" />
+
+#配置在提供者端
+<dubbo:service  ref="demoService" loadbalance="weightedconsistenthash" interface="com.alibaba.dubbo.demo.DemoService" />
+```
+
+同时还有另外一种配置方式：
+
+```
+#配置在消费者端
+<dubbo:consumer loadbalance="weightedconsistenthash" />
+
+#配置在提供者端
+<dubbo:provider loadbalance="weightedconsistenthash" />
+```
+
+Dubbo的配置体系中dubbo:reference与dubbo:service代表的是一个引用和一个服务。而dubbo:consumer标签与dubbo:provider代表的是所有的引用与服务，这两个标签中的配置是公共配置，对所有的应用与服务都生效。这里的优先级顺序是dubbo:reference比dubbo:service优先。
+
+在Dubbo的配置体系中的通用的原则是：
+
+```
+dubbo:reference > dubbo:service > dubbo:consumer > dubbo:provider
+```
+
+这里其实会碰到一个有问题的场景，如果服务提供端有多个，并且每个提供者配置了不同的参数，在消费者一方没有配置相应的参数，那么到底哪一个提供者的参数会生效呢，这个是不确定的。**所以强烈建议在消费者一端生效的参数尽量不要配置在提供者端。**
+
+另外请注意，对于哈希方式的负载均衡策略，默认情况下，是根据方法的第一个参数作为哈希的基础进行分片的，如果使用其它参数可以进行配置，以下是一个例子，表示取前三个参数作为哈希的基础：
+
+```
+<dubbo:reference id="demoService" interface="com.alibaba.dubbo.demo.DemoService">
+    <dubbo:method name="hello">
+        <dubbo:parameter key="hash.arguments" value="0,1,2"/>
+    </dubbo:method >
+</dubbo:reference>
+```
+
+
+### 实现方式
+
+该Feature的实现类是WeightedConsistentHashLoadBalance，这是一个基于一致性哈希实现的负载均衡策略，一致性哈希对比与简单哈希的好处是当增加或者减少服务提供者时，只会破坏一部分请求与服务提供者的映射关系，而简单哈希方式则会完全破坏之前的映射关系，所以选择了一致性哈希。
+
+对于权重特性的支持的实现思路是，构建一致性哈希环的时候，根据每个提供者的权重的大小，计算出相应的虚拟节点的数量，然后构建哈希环。
+
+![weight and virtual-node](http://image.cnthrowable.com/upload/throwable_blog/itbroblog/blog/1499047504152_217.png)
+
+对于服务预热特性的支持的实现思路是，在预热期间（默认是服务启动的10分钟）内，每分钟计算一次该服务的的动态权重，然后根据动态权重比例设置虚拟节点的数量
+
+```
+dynamicWeight=uptime/warmupTime*configuredWeight
+uptime : 服务启动的时间
+warmupTime : 预热期间，默认10分钟
+configuredWeight : 服务配置的权重，默认100
+```
+
+接下来分析预热功能对哈希Sticky特性的破坏。因为只有增加节点的场景服务预热功能才会生效，所以我们看增加节点的场景：
+
+![预热功能对Sticky特性的影响](http://image.cnthrowable.com/upload/throwable_blog/itbroblog/blog/1499065245188_649.png)
+
+通过观察以上的流程可以看到对于老的节点，在哈希环上对应的虚拟节点的数量和哈希值是不变的，整个预热期间变化的只要新增加服务的虚拟节点的数量。
+
+有没有预热功能对于哈希环的影响只是：一次性添加所有虚拟节点与缓慢添加虚拟节点的区别，但是两者最终哈希环的形态是一样的。所以我们认为服务预热功能是不会破坏Sticky特性的。

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
@@ -43,7 +43,7 @@ public abstract class AbstractLoadBalance implements LoadBalance {
     protected int getWeight(Invoker<?> invoker, Invocation invocation) {
         int weight = invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
         if (weight > 0) {
-	        long timestamp = invoker.getUrl().getParameter(Constants.TIMESTAMP_KEY, 0L);
+	        long timestamp = invoker.getUrl().getParameter(Constants.REMOTE_TIMESTAMP_KEY, 0L);
 	    	if (timestamp > 0L) {
 	    		int uptime = (int) (System.currentTimeMillis() - timestamp);
 	    		int warmup = invoker.getUrl().getParameter(Constants.WARMUP_KEY, Constants.DEFAULT_WARMUP);

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/WeightedConsistentHashLoadBalance.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/WeightedConsistentHashLoadBalance.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 1999-2012 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.rpc.cluster.loadbalance;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ *
+ * 带有权重与warmup功能的哈希负载均衡策略
+ *
+ * 权重特性实现方式：
+ *          一致性哈希的负载策略，跟据权重计算每个服务提供者的虚拟哈希节点的数量
+ *  warmup特性的实现方式：
+ *          在warmup期间，定时调整服务提供者的权重，并重新计算虚拟哈希节点的数量，并重建哈希环
+ *          因为重建哈希是一个重量级操作，所以warmup期间不是每次请求都重建哈希，而是每隔一分钟调整一次
+ *
+ * 注意在warmup此负载策略不具有sticky特性
+ * 注意默认使用第一个方法的参数作为哈希分片基准，如果服务方法没有参数，则所有的请求流到同一个节点，权重与warmup特性失效
+ *
+ * Created by wujianchao on 2017/6/7.
+ */
+public class WeightedConsistentHashLoadBalance extends AbstractLoadBalance {
+
+    public static final String NAME = "weightedconsistenthash";
+
+    private static final int MAX_VIRTUAL_NODE_NUM = 1000;
+
+    private static final float WEIGHT_FACTOR = 1.0f;
+
+    private static final Logger logger = LoggerFactory.getLogger(WeightedConsistentHashLoadBalance.class);
+
+    private final ConcurrentMap<String, WeightedConsistentHashSelector<?>> selectors = new ConcurrentHashMap<String, WeightedConsistentHashSelector<?>>();
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <T> Invoker<T> doSelect(List<Invoker<T>> invokers, URL url, Invocation invocation) {
+        String key = invokers.get(0).getUrl().getServiceKey() + "." + invocation.getMethodName();
+        int identityHashCode = System.identityHashCode(invokers);
+        WeightedConsistentHashSelector<T> selector = (WeightedConsistentHashSelector<T>) selectors.get(key);
+        if (selector == null) {
+            //发现新的服务类型，构建哈希
+            selector = new WeightedConsistentHashSelector<T>(invokers, invocation, identityHashCode);
+            selectors.put(key, selector);
+        } else if (selector.getIdentityHashCode() != identityHashCode) {
+            //服务提供者有变动，比如调整权重，必须重新构建WeightedConsistentHashSelector
+            logger.debug("Rebuild hash of service \"" + key + "\", for some of its providers change.");
+            selector = new WeightedConsistentHashSelector<T>(invokers, invocation, identityHashCode);
+            selectors.put(key, selector);
+        }
+        if (selector.isTimeToRebuildConsistentHash(invokers)) {
+            //服务提供者warnup期间，定时重建哈希，以达到缓慢增加权重的目的
+            logger.debug("Rebuild hash of service \"" + key + "\", for it is in warmup period.");
+            selector.buildConsistentHash(invokers, invocation);
+        }
+
+        return selector.select(invokers, invocation);
+    }
+
+    /**
+     * 默认使用第一个方法的参数作为哈希分片基准
+     * 注意如果服务方法没有参数，则所有的请求流到同一个节点
+     */
+    private final class WeightedConsistentHashSelector<T> {
+
+        private TreeMap<Long, Invoker<T>> virtualInvokers;
+
+        private final int replicaNumber;
+
+        private final int identityHashCode;
+
+        private final int[] argumentIndex;
+
+        //Make sure at least once rebuilding.
+        //When there is no request in a long time, no rebuilding will be triggered.
+        private AtomicBoolean isFirstStable = new AtomicBoolean(false);
+
+        //Next rebuild time
+        private AtomicLong nextwarmupTime = new AtomicLong(System.currentTimeMillis() + WARMUPPERIOD);
+
+        //Every WARMUPPERIOD time rebuild hash in warmup period.
+        private static final int WARMUPPERIOD = 60 * 1000;
+
+        public WeightedConsistentHashSelector(List<Invoker<T>> invokers, Invocation invocation, int identityHashCode) {
+            String methodName = invocation.getMethodName();
+            this.virtualInvokers = new TreeMap<Long, Invoker<T>>();
+            this.identityHashCode = identityHashCode;
+            URL url = invokers.get(0).getUrl();
+            this.replicaNumber = url.getMethodParameter(methodName, "hash.nodes", 160);
+            String[] index = Constants.COMMA_SPLIT_PATTERN.split(url.getMethodParameter(methodName, "hash.arguments", "0"));
+            argumentIndex = new int[index.length];
+            for (int i = 0; i < index.length; i++) {
+                argumentIndex[i] = Integer.parseInt(index[i]);
+            }
+
+            buildConsistentHash(invokers, invocation);
+        }
+
+        /**
+         * 根据服务提供者的权重设置虚拟节点数量，并以此来构建一致性哈希
+         * @param invokers 服务提供者
+         * @param invocation 一次RPC调用信息
+         */
+        private void buildConsistentHash(List<Invoker<T>> invokers, Invocation invocation) {
+
+            //总权重
+            int totalWeightWhenStable = 0;
+            for (Invoker<T> invoker : invokers) {
+                int configuredWeight = invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
+                if(configuredWeight > 0){
+                    //如果权重小于零，不计算在内
+                    totalWeightWhenStable += configuredWeight;
+                }
+            }
+
+            //多少个权重对应一个虚拟节点
+            float weightFactor = WEIGHT_FACTOR;
+            if(totalWeightWhenStable > MAX_VIRTUAL_NODE_NUM){
+                weightFactor = ((float)totalWeightWhenStable)/MAX_VIRTUAL_NODE_NUM;
+            }
+
+            //根据权重计算每个invoker对应一致性哈希环上的虚拟节点的个数
+            Map<Invoker<T>, Integer> virtualInvokerSize = new HashMap<Invoker<T>, Integer>();
+            for (Invoker<T> invoker : invokers) {
+                float tmpSize = (int) ((float) getWeight(invoker, invocation) /weightFactor);
+                //如果权重小于零，则不设置虚拟节点
+                tmpSize = tmpSize < 0.0f ? -1 : tmpSize;
+                int size = (int) tmpSize;
+                size = size == 0 ? 1 : size;
+                virtualInvokerSize.put(invoker, size);
+            }
+
+            //根据每个invoker的虚拟节点数量构建一致性哈希
+            //注意这里会重新构建哈希，是重量级操作
+            TreeMap<Long, Invoker<T>> newVirtualInvokers = new TreeMap<Long, Invoker<T>>();
+            for (Map.Entry<Invoker<T>, Integer> entry : virtualInvokerSize.entrySet()) {
+                for (int i = 0; i < entry.getValue(); i++) {
+                    byte[] digest = md5(entry.getKey().getUrl().toFullString() + i);
+                    long m = hash(digest, i % 4);
+                    newVirtualInvokers.put(m, entry.getKey());
+                }
+            }
+
+            //更新状态采用引用替换的方式，规避同步问题
+            virtualInvokers = newVirtualInvokers;
+
+            //打印新哈希信息
+            StringBuffer hashInfo = new StringBuffer();
+            if(logger.isDebugEnabled()){
+                for (Map.Entry<Invoker<T>, Integer> entry : virtualInvokerSize.entrySet()) {
+                    hashInfo.append("\n")
+                            .append(entry.getKey().getUrl().getAddress().toString())
+                            .append("=").append(entry.getValue());
+                }
+                logger.debug("Hash virtual nodes distribution info : " + hashInfo.toString());
+
+            }
+        }
+
+        /**
+         * 服务启动预热功能，设计上每个提供者（invoker）会在warmup时间内动态调整自己的权重
+         * 因为构建哈希环是重操作，所以不会每次请求都构建一次哈希，采用定时构建的方式
+         */
+        private <T> boolean isTimeToRebuildConsistentHash(List<Invoker<T>> invokers) {
+            if(invokers.size() == 1){
+                return false;
+            }
+            long current = System.currentTimeMillis();
+            boolean someoneInWarnupTime = false;
+            for (Invoker<T> invoker : invokers) {
+                long startup = invoker.getUrl().getParameter(Constants.REMOTE_TIMESTAMP_KEY, 0L);
+                long warmup = invoker.getUrl().getParameter(Constants.WARMUP_KEY, Constants.DEFAULT_WARMUP);
+                if (current < startup + warmup) {
+                    someoneInWarnupTime = true;
+                    break;
+                }
+            }
+
+            //Make sure at least once rebuilding.
+            //When there is no request in a long time, no rebuilding will be triggered.
+            if(!someoneInWarnupTime){
+                if(isFirstStable.compareAndSet(false, true)){
+                    return true;
+                }
+            }
+
+            if(someoneInWarnupTime && current >= nextwarmupTime.get()){
+                synchronized (nextwarmupTime){
+                    if(someoneInWarnupTime && current >= nextwarmupTime.get()){
+                        nextwarmupTime.getAndAdd(WARMUPPERIOD);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public int getIdentityHashCode() {
+            return identityHashCode;
+        }
+
+        public Invoker<T> select(List<Invoker<T>> invokers, Invocation invocation) {
+            String key = toKey(invocation.getArguments());
+            byte[] digest = md5(key);
+            Invoker<T> invoker = selectForKey(hash(digest, 0));
+            return invoker;
+        }
+
+        private String toKey(Object[] args) {
+            StringBuilder buf = new StringBuilder();
+            for (int i : argumentIndex) {
+                if (i >= 0 && i < args.length) {
+                    buf.append(args[i]);
+                }
+            }
+            return buf.toString();
+        }
+
+        private Invoker<T> selectForKey(long hash) {
+            TreeMap<Long, Invoker<T>> consistentHash = virtualInvokers;
+            Invoker<T> invoker;
+            Long key = hash;
+            if (!consistentHash.containsKey(key)) {
+                SortedMap<Long, Invoker<T>> tailMap = consistentHash.tailMap(key);
+                if (tailMap.isEmpty()) {
+                    key = consistentHash.firstKey();
+                } else {
+                    key = tailMap.firstKey();
+                }
+            }
+            invoker = consistentHash.get(key);
+            return invoker;
+        }
+
+        private long hash(byte[] digest, int number) {
+            return (((long) (digest[3 + number * 4] & 0xFF) << 24)
+                    | ((long) (digest[2 + number * 4] & 0xFF) << 16)
+                    | ((long) (digest[1 + number * 4] & 0xFF) << 8)
+                    | (digest[0 + number * 4] & 0xFF))
+                    & 0xFFFFFFFFL;
+        }
+
+        private byte[] md5(String value) {
+            MessageDigest md5;
+            try {
+                md5 = MessageDigest.getInstance("MD5");
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException(e.getMessage(), e);
+            }
+            md5.reset();
+            byte[] bytes = null;
+            try {
+                bytes = value.getBytes("UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalStateException(e.getMessage(), e);
+            }
+            md5.update(bytes);
+            return md5.digest();
+        }
+
+    }
+
+}

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/ClusterUtils.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/ClusterUtils.java
@@ -59,6 +59,10 @@ public class ClusterUtils {
         if (localMap != null && localMap.size() > 0) {
             map.putAll(localMap);
         }
+
+        //保留服务提供端的启动时间，以便AbstractLoadBalance计算warmup权重
+        map.put(Constants.REMOTE_TIMESTAMP_KEY, remoteMap.get(Constants.TIMESTAMP_KEY));
+
         if (remoteMap != null && remoteMap.size() > 0) { 
             // 版本号使用提供者的
             String dubbo = remoteMap.get(Constants.DUBBO_VERSION_KEY);

--- a/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.rpc.cluster.LoadBalance
+++ b/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.rpc.cluster.LoadBalance
@@ -2,3 +2,4 @@ random=com.alibaba.dubbo.rpc.cluster.loadbalance.RandomLoadBalance
 roundrobin=com.alibaba.dubbo.rpc.cluster.loadbalance.RoundRobinLoadBalance
 leastactive=com.alibaba.dubbo.rpc.cluster.loadbalance.LeastActiveLoadBalance
 consistenthash=com.alibaba.dubbo.rpc.cluster.loadbalance.ConsistentHashLoadBalance
+weightedconsistenthash=com.alibaba.dubbo.rpc.cluster.loadbalance.WeightedConsistentHashLoadBalance

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/loadbalance/TestService.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/loadbalance/TestService.java
@@ -1,0 +1,9 @@
+package com.alibaba.dubbo.rpc.cluster.loadbalance;
+
+/**
+ * Created by wujianchao on 2017/6/9.
+ */
+public interface TestService {
+
+    void doSomething(String arg1, String arg2);
+}

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/loadbalance/WeightedConsistentHashLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/loadbalance/WeightedConsistentHashLoadBalanceTest.java
@@ -1,0 +1,290 @@
+package com.alibaba.dubbo.rpc.cluster.loadbalance;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.extension.ExtensionLoader;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.cluster.LoadBalance;
+import com.alibaba.dubbo.rpc.support.MockInvoker;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Created by wujianchao on 2017/6/7.
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class WeightedConsistentHashLoadBalanceTest {
+
+    public static final String URL_PATTERN = "test://host-%d/TestService?"
+            + Constants.WEIGHT_KEY + "=%d&"
+            + Constants.WARMUP_KEY + "=%d&"
+            + Constants.REMOTE_TIMESTAMP_KEY + "=%d";
+
+    private int WARMUP = 2 * 60 * 1000;
+
+    private LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(WeightedConsistentHashLoadBalance.NAME);
+
+    private AtomicInteger HOST_ID = new AtomicInteger(0);
+    private int RUN_TIMES = 1000;
+
+    /**
+     * @throws Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+
+    }
+
+    private List<Invoker<TestService>> generateProviders(int weight){
+        List<Invoker<TestService>> result = new ArrayList<Invoker<TestService>>();
+        long current = System.currentTimeMillis();
+        //stable providers
+        for (int i = 0; i < 2; i++) {
+            URL url = URL.valueOf(String.format(URL_PATTERN, getHostId(), weight, WARMUP, (current - WARMUP)));
+            result.add(new MockInvoker<TestService>(url));
+            System.out.println("Stable service providers : " + url.toFullString());
+        }
+        //new provider double weight
+        for (int i = 0; i < 1; i++) {
+            URL url = URL.valueOf(String.format(URL_PATTERN, getHostId(), 2 * weight, WARMUP, current));
+            result.add(new MockInvoker<TestService>(url));
+            System.out.println("Adding new service providers : " + url.toFullString());
+        }
+        return result;
+    }
+
+    @Test
+    public void isTimeToRebuildConsistentHashTest() throws Exception {
+        Class WeightedConsistentHashSelectorClass = Class.forName(WeightedConsistentHashLoadBalance.class.getName()+"$WeightedConsistentHashSelector");
+        Method isTimeToRebuildConsistentHash = WeightedConsistentHashSelectorClass.getDeclaredMethod("isTimeToRebuildConsistentHash", List.class);
+        isTimeToRebuildConsistentHash.setAccessible(true);
+
+        List<Invoker<TestService>> invokers = generateProviders(100);
+
+        Object selector = WeightedConsistentHashSelectorClass.getDeclaredConstructors()[0]
+                .newInstance(lb, invokers, getInvocation(), System.identityHashCode(invokers));
+
+        boolean flag = (Boolean) isTimeToRebuildConsistentHash.invoke(selector, invokers);
+        Assert.assertFalse(flag);
+
+        Thread.sleep(10*1000);
+        flag = (Boolean) isTimeToRebuildConsistentHash.invoke(selector, invokers);
+        Assert.assertFalse(flag);
+
+        Thread.sleep(60*1000);
+        flag = (Boolean) isTimeToRebuildConsistentHash.invoke(selector, invokers);
+        Assert.assertTrue(flag);
+
+        Thread.sleep(60*1000);
+        flag = (Boolean) isTimeToRebuildConsistentHash.invoke(selector, invokers);
+        Assert.assertTrue(flag);
+
+        flag = (Boolean) isTimeToRebuildConsistentHash.invoke(selector, invokers);
+        Assert.assertFalse(flag);
+
+    }
+
+    @Test
+    public void isTimeToRebuildConsistentHashTestWhenNoRequestInWarmupTime() throws Exception {
+        Class WeightedConsistentHashSelectorClass = Class.forName(WeightedConsistentHashLoadBalance.class.getName()+"$WeightedConsistentHashSelector");
+        Method isTimeToRebuildConsistentHash = WeightedConsistentHashSelectorClass.getDeclaredMethod("isTimeToRebuildConsistentHash", List.class);
+        isTimeToRebuildConsistentHash.setAccessible(true);
+
+        List<Invoker<TestService>> invokers = generateProviders(100);
+
+        Object selector = WeightedConsistentHashSelectorClass.getDeclaredConstructors()[0]
+                .newInstance(lb, invokers, getInvocation(), System.identityHashCode(invokers));
+
+        boolean flag = (Boolean) isTimeToRebuildConsistentHash.invoke(selector, invokers);
+        Assert.assertFalse(!flag);
+
+        Thread.sleep(130*1000);
+        flag = (Boolean) isTimeToRebuildConsistentHash.invoke(selector, invokers);
+        Assert.assertFalse(flag);
+
+        flag = (Boolean) isTimeToRebuildConsistentHash.invoke(selector, invokers);
+        Assert.assertFalse(flag);
+
+    }
+
+
+    @Test
+    public void buildConsistentHashTest() throws Exception {
+        Class WeightedConsistentHashSelectorClass = Class.forName(WeightedConsistentHashLoadBalance.class.getName()+"$WeightedConsistentHashSelector");
+        Method buildConsistentHash = WeightedConsistentHashSelectorClass.getDeclaredMethod("buildConsistentHash", List.class, Invocation.class);
+        buildConsistentHash.setAccessible(true);
+        Field virtualInvokersField = WeightedConsistentHashSelectorClass.getDeclaredField("virtualInvokers");
+        virtualInvokersField.setAccessible(true);
+
+        List<Invoker<TestService>> invokers = generateProviders(100);
+
+        Object selector = WeightedConsistentHashSelectorClass.getDeclaredConstructors()[0]
+                .newInstance(lb, invokers, getInvocation(), System.identityHashCode(invokers));
+
+        Thread.sleep(10000);
+        buildConsistentHash.invoke(selector, invokers, getInvocation());
+        TreeMap<Long, Invoker> virtualInvokers = (TreeMap<Long, Invoker>) virtualInvokersField.get(selector);
+        Map<Invoker, Long> counter = countInvokerSize(virtualInvokers);
+        Assert.assertTrue(counter.get(invokers.get(0)) == invokers.get(0).getUrl().getParameter(Constants.WEIGHT_KEY, 0L));
+        Assert.assertTrue(counter.get(invokers.get(1)) == invokers.get(1).getUrl().getParameter(Constants.WEIGHT_KEY, 0L));
+        Assert.assertTrue(counter.get(invokers.get(2)) < invokers.get(2).getUrl().getParameter(Constants.WEIGHT_KEY, 0L));
+
+        Thread.sleep(WARMUP + 10* 1000);
+        buildConsistentHash.invoke(selector, invokers, getInvocation());
+        virtualInvokers = (TreeMap<Long, Invoker>) virtualInvokersField.get(selector);
+        counter = countInvokerSize(virtualInvokers);
+
+        Assert.assertTrue(counter.get(invokers.get(0)) == invokers.get(0).getUrl().getParameter(Constants.WEIGHT_KEY, 0L));
+        Assert.assertTrue(counter.get(invokers.get(1)) == invokers.get(1).getUrl().getParameter(Constants.WEIGHT_KEY, 0L));
+        Assert.assertTrue(counter.get(invokers.get(2)) == invokers.get(2).getUrl().getParameter(Constants.WEIGHT_KEY, 0L));
+    }
+
+    @Test
+    public void buildConsistentHashTestWhenTotalWeightLargerThan1000() throws Exception {
+        Class WeightedConsistentHashSelectorClass = Class.forName(WeightedConsistentHashLoadBalance.class.getName()+"$WeightedConsistentHashSelector");
+        Method buildConsistentHash = WeightedConsistentHashSelectorClass.getDeclaredMethod("buildConsistentHash", List.class, Invocation.class);
+        buildConsistentHash.setAccessible(true);
+        Field virtualInvokersField = WeightedConsistentHashSelectorClass.getDeclaredField("virtualInvokers");
+        virtualInvokersField.setAccessible(true);
+
+        List<Invoker<TestService>> invokers = generateProviders(1000);
+
+        Object selector = WeightedConsistentHashSelectorClass.getDeclaredConstructors()[0]
+                .newInstance(lb, invokers, getInvocation(), System.identityHashCode(invokers));
+
+        Thread.sleep(10000);
+        buildConsistentHash.invoke(selector, invokers, getInvocation());
+        TreeMap<Long, Invoker> virtualInvokers = (TreeMap<Long, Invoker>) virtualInvokersField.get(selector);
+        Map<Invoker, Long> counter = countInvokerSize(virtualInvokers);
+        //所有invoker的权重综合是4000，weightFactor=4
+        Assert.assertTrue(counter.get(invokers.get(0)) == invokers.get(0).getUrl().getParameter(Constants.WEIGHT_KEY, 0L)/4);
+        Assert.assertTrue(counter.get(invokers.get(1)) == invokers.get(1).getUrl().getParameter(Constants.WEIGHT_KEY, 0L)/4);
+        Assert.assertTrue(counter.get(invokers.get(2)) < invokers.get(2).getUrl().getParameter(Constants.WEIGHT_KEY, 0L)/4);
+
+        Thread.sleep(WARMUP + 10* 1000);
+        buildConsistentHash.invoke(selector, invokers, getInvocation());
+        virtualInvokers = (TreeMap<Long, Invoker>) virtualInvokersField.get(selector);
+        counter = countInvokerSize(virtualInvokers);
+
+        Assert.assertTrue(counter.get(invokers.get(0)) == invokers.get(0).getUrl().getParameter(Constants.WEIGHT_KEY, 0L)/4);
+        Assert.assertTrue(counter.get(invokers.get(1)) == invokers.get(1).getUrl().getParameter(Constants.WEIGHT_KEY, 0L)/4);
+        Assert.assertTrue(counter.get(invokers.get(2)) == invokers.get(2).getUrl().getParameter(Constants.WEIGHT_KEY, 0L)/4);
+    }
+
+    private Map<Invoker, Long>  countInvokerSize(TreeMap<Long, Invoker> virtualInvokers){
+        Map<Invoker, Long> counter = new HashMap<Invoker, Long>();
+        for (Map.Entry<Long, Invoker> entry : virtualInvokers.entrySet()) {
+            if(counter.get(entry.getValue()) == null){
+                counter.put(entry.getValue(), 1L);
+            }else{
+                counter.put(entry.getValue(), counter.get(entry.getValue()) + 1);
+            }
+        }
+        System.out.println(counter);
+        return counter;
+    }
+
+    private int getHostId() {
+        return HOST_ID.getAndIncrement();
+    }
+
+
+    /**
+     * new an invocation of different arguments
+     *
+     * @return invocation
+     */
+    public Invocation getInvocation() {
+        return new Invocation() {
+            public String getMethodName() {
+                return "doSomething";
+            }
+
+            public Class<?>[] getParameterTypes() {
+                return new Class[]{String.class, String.class};
+            }
+
+            public Object[] getArguments() {
+                return new String[]{"arg1" + new Random().nextFloat(), "arg2" + new Random().nextFloat()};
+            }
+
+
+            public Map<String, String> getAttachments() {
+                return null;
+            }
+
+            public String getAttachment(String key) {
+                return null;
+            }
+
+            public String getAttachment(String key, String defaultValue) {
+                return null;
+            }
+
+            public Invoker<?> getInvoker() {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void testWeightedConsistentHashLoadBalance() throws InterruptedException {
+
+        Map<Invoker, AtomicLong> counter = run(generateProviders(100), RUN_TIMES);
+
+        System.out.println("\nExecute info :");
+        for (Map.Entry<Invoker, AtomicLong> entry : counter.entrySet()) {
+            System.out.println(entry.getKey().getUrl().getHost().toString() + "=" + entry.getValue());
+        }
+    }
+
+    public Map<Invoker, AtomicLong> run(final List<Invoker<TestService>> invokers, int times) throws InterruptedException {
+        final Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<Invoker, AtomicLong>();
+        for (Invoker i : invokers) {
+            counter.put(i, new AtomicLong(0));
+        }
+
+        boolean newInvokerAdded = false;
+
+        //过了warmup后新增一个service provider
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    Thread.sleep(1000);
+                    System.out.println("New service provider up.");
+                    addInvoker(invokers, counter);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }).start();
+
+        //模拟长时间没有请求场景
+        Thread.sleep(WARMUP + 5000);
+
+        for (int i = 0; i < times; i++) {
+            Invoker invoker = lb.select(invokers, invokers.get(0).getUrl(), getInvocation());
+            counter.get(invoker).incrementAndGet();
+            Thread.sleep(200);
+        }
+
+        return counter;
+    }
+
+    private void addInvoker(List<Invoker<TestService>> invokers, Map<Invoker, AtomicLong> counter) {
+        URL url = URL.valueOf(String.format(URL_PATTERN, getHostId(), 100, WARMUP, System.currentTimeMillis()));
+        Invoker<TestService> invoker = new MockInvoker<TestService>(url);
+        invokers.add(invoker);
+        counter.put(invoker, new AtomicLong(0));
+    }
+
+}

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/ClusterUtilsTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/ClusterUtilsTest.java
@@ -42,6 +42,7 @@ public class ClusterUtilsTest {
             .addParameter(Constants.CORE_THREADS_KEY, Integer.MAX_VALUE)
             .addParameter(Constants.QUEUES_KEY, Integer.MAX_VALUE)
             .addParameter(Constants.ALIVE_KEY, Integer.MAX_VALUE)
+            .addParameter(Constants.TIMESTAMP_KEY, "100")
             .addParameter(Constants.DEFAULT_KEY_PREFIX + Constants.THREADS_KEY, Integer.MAX_VALUE)
             .addParameter(Constants.DEFAULT_KEY_PREFIX + Constants.THREADPOOL_KEY, "fixed")
             .addParameter(Constants.DEFAULT_KEY_PREFIX + Constants.CORE_THREADS_KEY, Integer.MAX_VALUE)
@@ -52,6 +53,7 @@ public class ClusterUtilsTest {
         URL consumerURL = URL.valueOf("dubbo://localhost:55555");
         consumerURL = consumerURL.addParameter(Constants.PID_KEY, "1234");
 	    consumerURL = consumerURL.addParameter(Constants.THREADPOOL_KEY, "foo");
+        consumerURL = consumerURL.addParameter(Constants.TIMESTAMP_KEY, "50");
 
         URL url = ClusterUtils.mergeUrl(providerURL, consumerURL.getParameters());
 
@@ -77,6 +79,8 @@ public class ClusterUtilsTest {
         Assert.assertEquals(url.getPassword(), "password");
         Assert.assertEquals(url.getParameter(Constants.PID_KEY), "1234");
 	    Assert.assertEquals(url.getParameter(Constants.THREADPOOL_KEY), "foo");
+        Assert.assertEquals(url.getParameter(Constants.TIMESTAMP_KEY), "50");
+        Assert.assertEquals(url.getParameter(Constants.REMOTE_TIMESTAMP_KEY), "100");
     }
 
 }

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
@@ -295,6 +295,8 @@ public class Constants {
     public static final String  PID_KEY                            = "pid";
 
     public static final String  TIMESTAMP_KEY                      = "timestamp";
+
+    public static final String REMOTE_TIMESTAMP_KEY              = "remote_timestamp";
     
     public static final String  WARMUP_KEY                         = "warmup";
 


### PR DESCRIPTION
Random roundrobin等负载均衡算法有warmup功能

Warmup指的是当一个provider启动的时候，请求量是逐渐从零开始累加的，而不是一次行过来。

Dubbo warmup功能实现的大概思路是，在每个provider启动的一个时期内，根据启动的时间与provider的权重计算一个新的权重，consumer根据这个新的权重去选择一个provider。
```
newWeight=(uptime/warmuptime)*weight
uptime指该provider启动了多长时间
warmuptime是一个时间段，默认是10分钟
weight是每个provider的权重
如果provider的启动时间超过了warmuptime则权重为原始的weight。
```

但是dubbo在计算每个provider的uptime的时候，使用的是consumer的开始时间，而不是对应provider的开始时间。这样导致每个provider计算出来的新权重都一样，从而失去了warmup的功能。

改正的思路是在consumer一端，引用服务，合并consumerURL与providerURL的时候，新增加一个参数“remote_timestamp”代表远端provider的启动时间，并且计算权重的时候使用这个参数值。

