### PR TITLE
修改了pom.xml文件，解决了source的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,14 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<plugin>  
+        		<groupId>org.apache.maven.plugins</groupId>  
+        		<artifactId>maven-compiler-plugin</artifactId>  
+        		<configuration>  
+          			<source>1.6</source>  
+          			<target>1.6</target>  
+        		</configuration>  
+      		</plugin>  
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
           			<source>1.6</source>  
           			<target>1.6</target>  
         		</configuration>  
-      		</plugin>  
+      		        </plugin>  
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
执行`mvn clean install -Dmaven.test.skip`时报错
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project hessian-lite: Compilation failure: Compilation failure:
[ERROR] /home/ye/dubbo/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Input.java:[279,3] 错误: -source 1.3 中不支持注释
......
```
修改：
pom文件中加入
```
<plugin>  
        		<groupId>org.apache.maven.plugins</groupId>  
        		<artifactId>maven-compiler-plugin</artifactId>  
        		<configuration>  
          			<source>1.6</source>  
          			<target>1.6</target>  
        		</configuration>  
      		</plugin>  
```