### PR TITLE
优化consumer找不到provider时的提示内容，当前提示容易误导使用者服务被禁用forbid

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
@@ -567,7 +567,11 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
 
     public List<Invoker<T>> doList(Invocation invocation) {
         if (forbidden) {
-            throw new RpcException(RpcException.FORBIDDEN_EXCEPTION, "Forbid consumer " + NetUtils.getLocalHost() + " access service " + getInterface().getName() + " from registry " + getUrl().getAddress() + " use dubbo version " + Version.getVersion() + ", Please check registry access list (whitelist/blacklist).");
+            // 1. 服务被禁用 2. 没有服务提供者
+            throw new RpcException(RpcException.FORBIDDEN_EXCEPTION,
+                "No service " + getInterface().getName()
+                    + " available from registry " + getUrl().getAddress() + " to consumer " +  NetUtils.getLocalHost()
+                    + " use dubbo version " + Version.getVersion() + ", may be services disabled or no providers ?");
         }
         List<Invoker<T>> invokers = null;
         Map<String, List<Invoker<T>>> localMethodInvokerMap = this.methodInvokerMap; // local reference


### PR DESCRIPTION
see https://github.com/alibaba/dubbo/issues/286