### PR TITLE
优化consumer找不到provider时的提示内容，当前提示容易误导使用者服务被禁用forbid

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
@@ -569,7 +569,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
         if (forbidden) {
             // 1. 没有服务提供者 2. 服务提供者被禁用
             throw new RpcException(RpcException.FORBIDDEN_EXCEPTION,
-                "No provider " + getInterfaceInfo()
+                "No provider " + getInterface0()
                     + " available from registry " + getUrl().getAddress() + " to consumer " +  NetUtils.getLocalHost()
                     + " use dubbo version " + Version.getVersion() + ", may be providers disabled or not registered ?");
         }
@@ -672,7 +672,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
     }
 
     // 构造 group/interface:version 用于提示消息
-    private String getInterfaceInfo() {
+    private String getInterface0() {
         StringBuilder sb = new StringBuilder();
         URL url = getConsumerUrl();
         String group, reversion;
@@ -680,7 +680,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
             sb.append(group).append("/");
         }
         sb.append(getInterface().getName());
-        if((reversion = url.getParameter(Constants.REVISION_KEY)) != null){
+        if((reversion = url.getParameter(Constants.VERSION_KEY)) != null){
             sb.append(":").append(reversion);
         }
         return sb.toString();

--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
@@ -569,7 +569,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
         if (forbidden) {
             // 1. 没有服务提供者 2. 服务提供者被禁用
             throw new RpcException(RpcException.FORBIDDEN_EXCEPTION,
-                "No provider " + getInterface0()
+                "No provider " + getConsumerUrl().getServiceKey()
                     + " available from registry " + getUrl().getAddress() + " to consumer " +  NetUtils.getLocalHost()
                     + " use dubbo version " + Version.getVersion() + ", may be providers disabled or not registered ?");
         }
@@ -669,20 +669,5 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
         public URL getProviderUrl() {
             return providerUrl;
         }
-    }
-
-    // 构造 group/interface:version 用于提示消息
-    private String getInterface0() {
-        StringBuilder sb = new StringBuilder();
-        URL url = getConsumerUrl();
-        String group, reversion;
-        if((group = url.getParameter(Constants.GROUP_KEY)) != null){
-            sb.append(group).append("/");
-        }
-        sb.append(getInterface().getName());
-        if((reversion = url.getParameter(Constants.VERSION_KEY)) != null){
-            sb.append(":").append(reversion);
-        }
-        return sb.toString();
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
@@ -569,8 +569,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
         if (forbidden) {
             // 1. 没有服务提供者 2. 服务提供者被禁用
             throw new RpcException(RpcException.FORBIDDEN_EXCEPTION,
-                "No provider " + getConsumerUrl().getServiceKey()
-                    + " available from registry " + getUrl().getAddress() + " to consumer " +  NetUtils.getLocalHost()
+                "No provider available from registry " + getUrl().getAddress() + " for service " + getConsumerUrl().getServiceKey() + " on consumer " +  NetUtils.getLocalHost()
                     + " use dubbo version " + Version.getVersion() + ", may be providers disabled or not registered ?");
         }
         List<Invoker<T>> invokers = null;


### PR DESCRIPTION
detail: see https://github.com/alibaba/dubbo/issues/286