### PR TITLE
修复executes属性（ExecuteLimitFilter）在高并发时无法真正限制某个接口或方法使用线程数的bug(修复CLA认证问题)

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcStatus.java
@@ -157,7 +157,7 @@ public class RpcStatus {
     private final AtomicLong succeededMaxElapsed = new AtomicLong();
 
     /**
-     * 用来实现executes属性的并发限制（即能使用的线程数目限制）
+     * 用来实现executes属性的并发限制（即控制能使用的线程数）
      * 2017-08-21 yizhenqiang
      */
     private volatile Semaphore executesLimit;
@@ -326,7 +326,7 @@ public class RpcStatus {
     }
 
     /**
-     * 获取一个线程许可
+     * 获取一个信号量，信号量的许可数就是executes设置的值
      * 2017-08-21 yizhenqiang
      * @param max
      * @return

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcStatus.java
@@ -157,7 +157,7 @@ public class RpcStatus {
     private final AtomicLong succeededMaxElapsed = new AtomicLong();
 
     /**
-     * 用来配合executes属性来限制并发（使用线程数目）的限制
+     * 用来实现executes属性的并发限制（即能使用的线程数目限制）
      * 2017-08-21 yizhenqiang
      */
     private volatile Semaphore executesLimit;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/ExecuteLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/ExecuteLimitFilter.java
@@ -46,7 +46,8 @@ public class ExecuteLimitFilter implements Filter {
 
             // if (count.getActive() >= max) {
             /**
-             * 这里通过信号量来做并发（使用线程数量）控制
+             * http://manzhizhen.iteye.com/blog/2386408
+             * 通过信号量来做并发控制（即限制能使用的线程数量）
              * 2017-08-21 yizhenqiang
              */
             executesLimit = count.getSemaphore(max);


### PR DESCRIPTION
该提交主要是修复executes属性（ExecuteLimitFilter ）在高并发情况下的bug，在高并发情况下，executes无法真正限制该接口能使用的线程数。（同https://github.com/alibaba/dubbo/pull/539，修复CLA认证问题）
请参考博文：http://manzhizhen.iteye.com/blog/2386408
微信：18668225833