### PR TITLE
修复executes属性（ExecuteLimitFilter）在高并发时无法真正限制某个接口或方法使用线程数的bug

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcStatus.java
@@ -19,6 +19,7 @@ import com.alibaba.dubbo.common.URL;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -44,6 +45,12 @@ public class RpcStatus {
     private final AtomicLong maxElapsed = new AtomicLong();
     private final AtomicLong failedMaxElapsed = new AtomicLong();
     private final AtomicLong succeededMaxElapsed = new AtomicLong();
+
+    /**
+     * 用来实现executes属性的并发限制（即控制能使用的线程数）
+     * 2017-08-21 yizhenqiang
+     */
+    private volatile Semaphore executesLimit;
 
     private RpcStatus() {
     }
@@ -302,6 +309,28 @@ public class RpcStatus {
             return getTotal() / (getTotalElapsed() / 1000L);
         }
         return getTotal();
+    }
+
+    /**
+     * 获取限制线程数的信号量，信号量的许可数就是executes设置的值
+     * 2017-08-21 yizhenqiang
+     * @param maxThreadNum executes设置的值
+     * @return
+     */
+    public Semaphore getSemaphore(int maxThreadNum) {
+        if(maxThreadNum <= 0) {
+            return null;
+        }
+
+        if(executesLimit == null) {
+            synchronized (this) {
+                if(executesLimit == null) {
+                    executesLimit = new Semaphore(maxThreadNum);
+                }
+            }
+        }
+
+        return executesLimit;
     }
 
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcStatus.java
@@ -51,6 +51,7 @@ public class RpcStatus {
      * 2017-08-21 yizhenqiang
      */
     private volatile Semaphore executesLimit;
+    private volatile int executesPermits;
 
     private RpcStatus() {
     }
@@ -322,15 +323,15 @@ public class RpcStatus {
             return null;
         }
 
-        if(executesLimit == null) {
+        if (executesLimit == null || executesPermits != maxThreadNum) {
             synchronized (this) {
-                if(executesLimit == null) {
+                if (executesLimit == null || executesPermits != maxThreadNum) {
                     executesLimit = new Semaphore(maxThreadNum);
+                    executesPermits = maxThreadNum;
                 }
             }
         }
 
         return executesLimit;
     }
-
 }


### PR DESCRIPTION
修复executes属性（ExecuteLimitFilter）在高并发时无法真正限制某个接口或方法使用线程数的bug。
参见：http://manzhizhen.iteye.com/blog/2386408

这个bug只有在高并发的情况下容易出现（比如并发大于100），问题其实主要在于“计数器和阈值的比较”和“计数器加1”不是一个原子操作，会产生竞态条件的问题，所以可改用信号量来解决这个问题。

微信/手机：18668225833