### PR TITLE
fix:#558 修复 Builder#newObjectBuilder 存在死循环的风险

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/serialize/support/dubbo/Builder.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/serialize/support/dubbo/Builder.java
@@ -983,7 +983,7 @@ public abstract class Builder<T> implements GenericDataFlags {
                 t = t.getSuperclass();
                 if (t == null)
                     throw new RuntimeException("Can not found Constructor?");
-                cs = c.getDeclaredConstructors();
+                cs = t.getDeclaredConstructors();
             }
             while (cs.length == 0);
         }


### PR DESCRIPTION
修复 com.alibaba.dubbo.common.serialize.support.dubbo.Builder#newObjectBuilder 存在死循环的风险