### PR TITLE
bugfix: 一致性哈希负载均衡bug

### DIFF
--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
@@ -44,7 +44,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
         String key = invokers.get(0).getUrl().getServiceKey() + "." + invocation.getMethodName();
         int identityHashCode = System.identityHashCode(invokers);
         ConsistentHashSelector<T> selector = (ConsistentHashSelector<T>) selectors.get(key);
-        if (selector == null || selector.getIdentityHashCode() != identityHashCode) {
+        if (selector == null || selector.identityHashCode != identityHashCode) {
             selectors.put(key, new ConsistentHashSelector<T>(invokers, invocation.getMethodName(), identityHashCode));
             selector = (ConsistentHashSelector<T>) selectors.get(key);
         }
@@ -61,9 +61,9 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
 
         private final int[] argumentIndex;
 
-        public ConsistentHashSelector(List<Invoker<T>> invokers, String methodName, int identityHashCode) {
+        ConsistentHashSelector(List<Invoker<T>> invokers, String methodName, int identityHashCode) {
             this.virtualInvokers = new TreeMap<Long, Invoker<T>>();
-            this.identityHashCode = System.identityHashCode(invokers);
+            this.identityHashCode = identityHashCode;
             URL url = invokers.get(0).getUrl();
             this.replicaNumber = url.getMethodParameter(methodName, "hash.nodes", 160);
             String[] index = Constants.COMMA_SPLIT_PATTERN.split(url.getMethodParameter(methodName, "hash.arguments", "0"));
@@ -72,8 +72,9 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
                 argumentIndex[i] = Integer.parseInt(index[i]);
             }
             for (Invoker<T> invoker : invokers) {
+                String address = invoker.getUrl().getAddress();
                 for (int i = 0; i < replicaNumber / 4; i++) {
-                    byte[] digest = md5(invoker.getUrl().toFullString() + i);
+                    byte[] digest = md5(address + i);
                     for (int h = 0; h < 4; h++) {
                         long m = hash(digest, h);
                         virtualInvokers.put(m, invoker);
@@ -82,15 +83,10 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
             }
         }
 
-        public int getIdentityHashCode() {
-            return identityHashCode;
-        }
-
         public Invoker<T> select(Invocation invocation) {
             String key = toKey(invocation.getArguments());
             byte[] digest = md5(key);
-            Invoker<T> invoker = sekectForKey(hash(digest, 0));
-            return invoker;
+            return selectForKey(hash(digest, 0));
         }
 
         private String toKey(Object[] args) {
@@ -103,7 +99,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
             return buf.toString();
         }
 
-        private Invoker<T> sekectForKey(long hash) {
+        private Invoker<T> selectForKey(long hash) {
             Invoker<T> invoker;
             Long key = hash;
             if (!virtualInvokers.containsKey(key)) {
@@ -122,7 +118,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
             return (((long) (digest[3 + number * 4] & 0xFF) << 24)
                     | ((long) (digest[2 + number * 4] & 0xFF) << 16)
                     | ((long) (digest[1 + number * 4] & 0xFF) << 8)
-                    | (digest[0 + number * 4] & 0xFF))
+                    | (digest[number * 4] & 0xFF))
                     & 0xFFFFFFFFL;
         }
 
@@ -134,7 +130,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
                 throw new IllegalStateException(e.getMessage(), e);
             }
             md5.reset();
-            byte[] bytes = null;
+            byte[] bytes;
             try {
                 bytes = value.getBytes("UTF-8");
             } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
bugfix: 计算一致性哈希的时候使用了invoker.getUrl().toFullString()，这个toFullString里包含一个服务暴露时候的时间戳，那么一个provider的再次暴露时间戳就变了，一致性哈希的节点也会改变，改成用address更合理些。另外就是修正一些IDE warning。