### PR TITLE
bugfix: 修正zk timeout

### DIFF
--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/com/alibaba/dubbo/remoting/zookeeper/zkclient/ZkclientZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/com/alibaba/dubbo/remoting/zookeeper/zkclient/ZkclientZookeeperClient.java
@@ -22,7 +22,7 @@ public class ZkclientZookeeperClient extends AbstractZookeeperClient<IZkChildLis
 
     public ZkclientZookeeperClient(URL url) {
         super(url);
-        client = new ZkClient(url.getBackupAddress());
+        client = new ZkClient(url.getBackupAddress(), 5 * 1000);
         client.subscribeStateChanges(new IZkStateListener() {
             public void handleStateChanged(KeeperState state) throws Exception {
                 ZkclientZookeeperClient.this.state = state;


### PR DESCRIPTION
bugfix: 这里默认的zk timeout是Integer.MAX_VALUE，如果zk有问题或网络有问题这里会hang住，修改成和curator版本client一样的timeout