### PR TITLE
简化OverrideListener的逻辑

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryProtocol.java
@@ -121,7 +121,7 @@ public class RegistryProtocol implements Protocol {
         // 订阅override数据
         // FIXME 提供者订阅时，会影响同一JVM即暴露服务，又引用同一服务的的场景，因为subscribed以服务名为缓存的key，导致订阅信息覆盖。
         final URL overrideSubscribeUrl = getSubscribedOverrideUrl(registedProviderUrl);
-        final OverrideListener overrideSubscribeListener = new OverrideListener(overrideSubscribeUrl);
+        final OverrideListener overrideSubscribeListener = new OverrideListener(overrideSubscribeUrl, originInvoker);
         overrideListeners.put(overrideSubscribeUrl, overrideSubscribeListener);
         registry.subscribe(overrideSubscribeUrl, overrideSubscribeListener);
         //保证每次export都返回一个新的exporter实例
@@ -165,7 +165,7 @@ public class RegistryProtocol implements Protocol {
                 }
             }
         }
-        return (ExporterChangeableWrapper<T>) exporter;
+        return exporter;
     }
 
     /**
@@ -180,7 +180,6 @@ public class RegistryProtocol implements Protocol {
         final ExporterChangeableWrapper<T> exporter = (ExporterChangeableWrapper<T>) bounds.get(key);
         if (exporter == null) {
             logger.warn(new IllegalStateException("error state, exporter should not be null"));
-            return;//不存在是异常场景 直接返回
         } else {
             final Invoker<T> invokerDelegete = new InvokerDelegete<T>(originInvoker, newInvokerUrl);
             exporter.setExporter(protocol.export(invokerDelegete));
@@ -327,67 +326,73 @@ public class RegistryProtocol implements Protocol {
     private class OverrideListener implements NotifyListener {
 
         private final URL subscribeUrl;
-        private volatile List<Configurator> configurators;
+        private final Invoker originInvoker;
 
-        public OverrideListener(URL subscribeUrl) {
+        public OverrideListener(URL subscribeUrl, Invoker originalInvoker) {
             this.subscribeUrl = subscribeUrl;
+            this.originInvoker = originalInvoker;
         }
 
-        /*
-         *  provider 端可识别的override url只有这两种.
-         *  override://0.0.0.0/serviceName?timeout=10
-         *  override://0.0.0.0/?timeout=10
+        /**
+         * @param urls 已注册信息列表，总不为空，含义同{@link com.alibaba.dubbo.registry.RegistryService#lookup(URL)}的返回值。
          */
-        public void notify(List<URL> urls) {
-            List<URL> result = null;
-            for (URL url : urls) {
+        public synchronized void notify(List<URL> urls) {
+            logger.debug("original override urls: " + urls);
+            List<URL> matchedUrls = getMatchedUrls(urls, subscribeUrl);
+            logger.debug("subscribe url: " + subscribeUrl + ", override urls: " + matchedUrls);
+            //没有匹配的
+            if (matchedUrls.isEmpty()) {
+                return;
+            }
+
+            List<Configurator> configurators = RegistryDirectory.toConfigurators(matchedUrls);
+
+            final Invoker<?> invoker;
+            if (originInvoker instanceof InvokerDelegete) {
+                invoker = ((InvokerDelegete<?>) originInvoker).getInvoker();
+            } else {
+                invoker = originInvoker;
+            }
+            //最原始的invoker
+            URL originUrl = RegistryProtocol.this.getProviderUrl(invoker);
+            String key = getCacheKey(originInvoker);
+            ExporterChangeableWrapper<?> exporter = bounds.get(key);
+            if (exporter == null) {
+                logger.warn(new IllegalStateException("error state, exporter should not be null"));
+                return;
+            }
+            //当前的，可能经过了多次merge
+            URL currentUrl = exporter.getInvoker().getUrl();
+            //与本次配置merge的
+            URL newUrl = getConfigedInvokerUrl(configurators, originUrl);
+            if (!currentUrl.equals(newUrl)) {
+                RegistryProtocol.this.doChangeLocalExport(originInvoker, newUrl);
+                logger.info("exported provider url changed, origin url: " + originUrl + ", old export url: " + currentUrl + ", new export url: " + newUrl);
+            }
+        }
+
+        private List<URL> getMatchedUrls(List<URL> configuratorUrls, URL currentSubscribe) {
+            List<URL> result = new ArrayList<URL>();
+            for (URL url : configuratorUrls) {
                 URL overrideUrl = url;
+                // 兼容旧版本
                 if (url.getParameter(Constants.CATEGORY_KEY) == null
                         && Constants.OVERRIDE_PROTOCOL.equals(url.getProtocol())) {
-                    // 兼容旧版本
                     overrideUrl = url.addParameter(Constants.CATEGORY_KEY, Constants.CONFIGURATORS_CATEGORY);
                 }
-                if (!UrlUtils.isMatch(subscribeUrl, overrideUrl)) {
-                    if (result == null) {
-                        result = new ArrayList<URL>(urls);
-                    }
-                    result.remove(url);
-                    logger.warn("Subsribe category=configurator, but notifed non-configurator urls. may be registry bug. unexcepted url: " + url);
-                }
-            }
-            if (result != null) {
-                urls = result;
-            }
-            this.configurators = RegistryDirectory.toConfigurators(urls);
-            List<ExporterChangeableWrapper<?>> exporters = new ArrayList<ExporterChangeableWrapper<?>>(bounds.values());
-            for (ExporterChangeableWrapper<?> exporter : exporters) {
-                Invoker<?> invoker = exporter.getOriginInvoker();
-                final Invoker<?> originInvoker;
-                if (invoker instanceof InvokerDelegete) {
-                    originInvoker = ((InvokerDelegete<?>) invoker).getInvoker();
-                } else {
-                    originInvoker = invoker;
-                }
 
-                URL originUrl = RegistryProtocol.this.getProviderUrl(originInvoker);
-                //增加判断：只有 当前服务与override指定服务 匹配时，override才生效
-                if (urls != null && urls.size() > 0 && originUrl.getServiceKey().equals(urls.get(0).getServiceKey())) {
-                    URL newUrl = getNewInvokerUrl(originUrl, urls);
-
-                    if (!originUrl.equals(newUrl) || (this.configurators == null || this.configurators.size() == 0)) {
-                        RegistryProtocol.this.doChangeLocalExport(originInvoker, newUrl);
-                    }
+                //检查是不是要应用到当前服务上
+                if (UrlUtils.isMatch(currentSubscribe, overrideUrl)) {
+                    result.add(url);
                 }
             }
+            return result;
         }
 
-        private URL getNewInvokerUrl(URL url, List<URL> urls) {
-            List<Configurator> localConfigurators = this.configurators; // local reference
-            // 合并override参数
-            if (localConfigurators != null && localConfigurators.size() > 0) {
-                for (Configurator configurator : localConfigurators) {
-                    url = configurator.configure(url);
-                }
+        //合并配置的url
+        private URL getConfigedInvokerUrl(List<Configurator> configurators, URL url) {
+            for (Configurator configurator : configurators) {
+                url = configurator.configure(url);
             }
             return url;
         }


### PR DESCRIPTION
这里每个服务export的时候都会订阅一个OverrideListener，那么configurators节点发生变动的时候，每个服务的OverrideListener都会触发，那每个服务的OverrideListener去修改自己就好了，为什么要把bounds里全拿出来呢？还增加了出bug的几率