### PR TITLE
希望能调大AbstractConfig中对配置值长度的限制（MAX_LENGTH）

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
@@ -44,7 +44,7 @@ public abstract class AbstractConfig implements Serializable {
 
     protected static final Logger logger = LoggerFactory.getLogger(AbstractConfig.class);
     private static final long serialVersionUID = 4267533505537413570L;
-    private static final int MAX_LENGTH = 100;
+    private static final int MAX_LENGTH = 300;
 
     private static final int MAX_PATH_LENGTH = 200;
 

--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
@@ -44,7 +44,7 @@ public abstract class AbstractConfig implements Serializable {
 
     protected static final Logger logger = LoggerFactory.getLogger(AbstractConfig.class);
     private static final long serialVersionUID = 4267533505537413570L;
-    private static final int MAX_LENGTH = 300;
+    private static final int MAX_LENGTH = 200;
 
     private static final int MAX_PATH_LENGTH = 200;
 


### PR DESCRIPTION
使用dubbo过程中有一个比较头疼的限制，那就是AbstractConfig中的MAX_LENGTH，它的值是100。
我们公司内部经常会通过Filter来在dubbo中做一些“埋点”处理，比如输出监控、日志、接入分布式跟踪系统等，所以在dubbo中配置5、6个Filter类是常有的事，加起来字符数是一百多，所以启动时却被AbstractConfig中的MAX_LENGTH给限制住了，所以希望能在新的版本中，将这个值给放宽，不知道改成200可否？谢谢。