### PR TITLE
fix: 这里destroy的顺序反了

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ProtocolConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ProtocolConfig.java
@@ -144,7 +144,6 @@ public class ProtocolConfig extends AbstractConfig {
         if (!destroyed.compareAndSet(false, true)) {
             return;
         }
-        AbstractRegistryFactory.destroyAll();
         ExtensionLoader<Protocol> loader = ExtensionLoader.getExtensionLoader(Protocol.class);
         for (String protocolName : loader.getLoadedExtensions()) {
             try {
@@ -156,6 +155,7 @@ public class ProtocolConfig extends AbstractConfig {
                 logger.warn(t.getMessage(), t);
             }
         }
+        AbstractRegistryFactory.destroyAll();
     }
 
     @Parameter(excluded = true)


### PR DESCRIPTION
fix: 这里destroy的顺序反了，registry先destroy后与zk连接关闭了，然后再destroy protocol还会去zk上反注册，这样就抛异常了。不过这个问题不是什么大问题，一般调用这个方法也是停止应用的时候，只是抛出一堆异常有点讨厌。