### PR TITLE
增加MethodValidated注解，修改JValidator.java，在接口方法上支持多个自定义分组参数验证；

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
@@ -73,8 +73,7 @@ public class Constants {
 
     public static final String $ECHO = "$echo";
 
-    public static final int DEFAULT_IO_THREADS = Runtime.getRuntime()
-            .availableProcessors() + 1;
+    public static final int DEFAULT_IO_THREADS = Math.min(Runtime.getRuntime().availableProcessors() + 1, 32);
 
     public static final String DEFAULT_PROXY = "javassist";
 

--- a/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/validation/ValidationParameter.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/validation/ValidationParameter.java
@@ -34,6 +34,9 @@ public class ValidationParameter implements Serializable {
 
     private static final long serialVersionUID = 7158911668568000392L;
 
+    @NotNull(groups = ValidationService.Update.class)
+    private Integer id;
+
     @NotNull // 不允许为空
     @Size(min = 2, max = 20) // 长度或大小范围
     private String name;
@@ -51,6 +54,14 @@ public class ValidationParameter implements Serializable {
 
     @Future // 必须为一个未来的时间
     private Date expiryDate;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
 
     public String getName() {
         return name;

--- a/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/validation/ValidationService.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/validation/ValidationService.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.dubbo.config.validation;
 
+import com.alibaba.dubbo.validation.MethodValidated;
+
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -28,16 +30,31 @@ import javax.validation.constraints.Size;
  */
 public interface ValidationService { // 缺省可按服务接口区分验证场景，如：@NotNull(groups = ValidationService.class)
 
+    /**
+     *  没有加上“@MethodValidated(ValidationService.Save.class)”这句代码时，
+     *  现在的检查逻辑不会去检验groups = ValidationService.Save.class这个分组
+     *
+     * @param parameter
+     */
+    @MethodValidated(ValidationService.Save.class)
     void save(ValidationParameter parameter);
 
     void update(ValidationParameter parameter);
 
     void delete(@Min(1) long id, @NotNull @Size(min = 2, max = 16) @Pattern(regexp = "^[a-zA-Z]+$") String operator);
 
+    /**
+     * 假设关联查询的时候需要同时传id和email的值。这时需要检查Sava分组和Update分组。
+     * @param parameter
+     */
+    @MethodValidated({ValidationService.Save.class, ValidationService.Update.class})
+    void relatedQuery(ValidationParameter parameter);
+
     @interface Save {
     } // 与方法同名接口，首字母大写，用于区分验证场景，如：@NotNull(groups = ValidationService.Save.class)，可选
 
     @interface Update {
     } // 与方法同名接口，首字母大写，用于区分验证场景，如：@NotNull(groups = ValidationService.Update.class)，可选
+
 
 }

--- a/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/validation/ValidationServiceImpl.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/validation/ValidationServiceImpl.java
@@ -31,4 +31,8 @@ public class ValidationServiceImpl implements ValidationService {
     public void delete(long id, String operator) {
     }
 
+    public void relatedQuery(ValidationParameter parameter){
+
+    }
+
 }

--- a/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/validation/ValidationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/validation/ValidationTest.java
@@ -81,6 +81,36 @@ public class ValidationTest {
                     Assert.assertNotNull(violations);
                 }
 
+                //检查Save分组 save error
+                try {
+                    parameter = new ValidationParameter();
+                    parameter.setName("liangfei");
+                    parameter.setAge(50);
+                    parameter.setLoginDate(new Date(System.currentTimeMillis() - 1000000));
+                    parameter.setExpiryDate(new Date(System.currentTimeMillis() + 1000000));
+                    validationService.save(parameter);
+                    Assert.fail();
+                } catch (RpcException e) {
+                    ConstraintViolationException ve = (ConstraintViolationException) e.getCause();
+                    Set<ConstraintViolation<?>> violations = ve.getConstraintViolations();
+                    Assert.assertNotNull(violations);
+                }
+
+                // relatedQuery error 不传id和email的值，触发Save和Update的检查异常
+                try {
+                    parameter = new ValidationParameter();
+                    parameter.setName("liangfei");
+                    parameter.setAge(50);
+                    parameter.setLoginDate(new Date(System.currentTimeMillis() - 1000000));
+                    parameter.setExpiryDate(new Date(System.currentTimeMillis() + 1000000));
+                    validationService.relatedQuery(parameter);
+                    Assert.fail();
+                } catch (RpcException e) {
+                    ConstraintViolationException ve = (ConstraintViolationException) e.getCause();
+                    Set<ConstraintViolation<?>> violations = ve.getConstraintViolations();
+                    Assert.assertEquals(violations.size(),2);
+                }
+
                 // Save Error
                 try {
                     parameter = new ValidationParameter();

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/com/alibaba/dubbo/validation/MethodValidated.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/com/alibaba/dubbo/validation/MethodValidated.java
@@ -1,0 +1,19 @@
+package com.alibaba.dubbo.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 方法分组验证注解
+ * @author: zhangyinyue
+ * @Createdate: 2017年10月10日 16:34
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MethodValidated {
+    Class<?>[] value() default {};
+}

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/com/alibaba/dubbo/validation/MethodValidated.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/com/alibaba/dubbo/validation/MethodValidated.java
@@ -8,6 +8,11 @@ import java.lang.annotation.Target;
 
 /**
  * 方法分组验证注解
+ * 使用场景：当调用某个方法时，需要检查多个分组，可以在接口方法上加上该注解
+ * 用法 在接口方法上增加注解，如：
+ *  @MethodValidated({ValidationService.Save.class, ValidationService.Update.class})
+ *  void relatedQuery(ValidationParameter parameter);
+ * 表示relatedQuery这个方法需要同时检查Save和Update这两个分组
  * @author: zhangyinyue
  * @Createdate: 2017年10月10日 16:34
  */

--- a/dubbo-remoting/dubbo-remoting-netty4/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty4/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-remoting</artifactId>
+        <groupId>com.alibaba</groupId>
+        <version>2.5.5</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-remoting-netty4</artifactId>
+    <packaging>jar</packaging>
+
+    <name>dubbo-remoting-netty4</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-remoting-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.0.35.Final</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyBackedChannelBuffer.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyBackedChannelBuffer.java
@@ -1,0 +1,373 @@
+package com.alibaba.dubbo.remoting.transport.netty4;
+
+import com.alibaba.dubbo.common.utils.Assert;
+import com.alibaba.dubbo.remoting.buffer.ChannelBuffer;
+import com.alibaba.dubbo.remoting.buffer.ChannelBufferFactory;
+import com.alibaba.dubbo.remoting.buffer.ChannelBuffers;
+import io.netty.buffer.ByteBuf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * @author <a href="mailto:gang.lvg@taobao.com">kimi</a>
+ */
+public class NettyBackedChannelBuffer implements ChannelBuffer {
+
+    private ByteBuf buffer;
+
+    public NettyBackedChannelBuffer(ByteBuf buffer) {
+        Assert.notNull(buffer, "buffer == null");
+        this.buffer = buffer;
+    }
+
+    
+    public int capacity() {
+        return buffer.capacity();
+    }
+
+    
+    public ChannelBuffer copy(int index, int length) {
+        return new NettyBackedChannelBuffer(buffer.copy(index, length));
+    }
+
+    //has nothing use
+    public ChannelBufferFactory factory() {
+        return null;
+    }
+
+    
+    public byte getByte(int index) {
+        return buffer.getByte(index);
+    }
+
+    
+    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+        buffer.getBytes(index, dst, dstIndex, length);
+    }
+
+    
+    public void getBytes(int index, ByteBuffer dst) {
+        buffer.getBytes(index, dst);
+    }
+
+    
+    public void getBytes(int index, ChannelBuffer dst, int dstIndex, int length) {
+        // careful
+        byte[] data = new byte[length];
+        buffer.getBytes(index, data, 0, length);
+        dst.setBytes(dstIndex, data, 0, length);
+    }
+
+    
+    public void getBytes(int index, OutputStream dst, int length) throws IOException {
+        buffer.getBytes(index, dst, length);
+    }
+
+    
+    public boolean isDirect() {
+        return buffer.isDirect();
+    }
+
+    
+    public void setByte(int index, int value) {
+        buffer.setByte(index, value);
+    }
+
+    
+    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+        buffer.setBytes(index, src, srcIndex, length);
+    }
+
+    
+    public void setBytes(int index, ByteBuffer src) {
+        buffer.setBytes(index, src);
+    }
+
+    
+    public void setBytes(int index, ChannelBuffer src, int srcIndex, int length) {
+        // careful
+        byte[] data = new byte[length];
+        buffer.getBytes(srcIndex, data, 0, length);
+        setBytes(0, data, index, length);
+    }
+
+    
+    public int setBytes(int index, InputStream src, int length) throws IOException {
+        return buffer.setBytes(index, src, length);
+    }
+
+    
+    public ByteBuffer toByteBuffer(int index, int length) {
+        return buffer.nioBuffer(index, length);
+    }
+
+    
+    public byte[] array() {
+        return buffer.array();
+    }
+
+    
+    public boolean hasArray() {
+        return buffer.hasArray();
+    }
+
+    
+    public int arrayOffset() {
+        return buffer.arrayOffset();
+    }
+
+
+    // AbstractChannelBuffer
+
+
+    
+    public void clear() {
+        buffer.clear();
+    }
+
+    
+    public ChannelBuffer copy() {
+        return new NettyBackedChannelBuffer(buffer.copy());
+    }
+
+    
+    public void discardReadBytes() {
+        buffer.discardReadBytes();
+    }
+
+    
+    public void ensureWritableBytes(int writableBytes) {
+        buffer.ensureWritable(writableBytes);
+    }
+
+    
+    public void getBytes(int index, byte[] dst) {
+        buffer.getBytes(index, dst);
+    }
+
+    
+    public void getBytes(int index, ChannelBuffer dst) {
+        // careful
+        getBytes(index, dst, dst.writableBytes());
+    }
+
+    
+    public void getBytes(int index, ChannelBuffer dst, int length) {
+        // careful
+        if (length > dst.writableBytes()) {
+            throw new IndexOutOfBoundsException();
+        }
+        getBytes(index, dst, dst.writerIndex(), length);
+        dst.writerIndex(dst.writerIndex() + length);
+    }
+
+    
+    public void markReaderIndex() {
+        buffer.markReaderIndex();
+    }
+
+    
+    public void markWriterIndex() {
+        buffer.markWriterIndex();
+    }
+
+    
+    public boolean readable() {
+        return buffer.isReadable();
+    }
+
+    
+    public int readableBytes() {
+        return buffer.readableBytes();
+    }
+
+    
+    public byte readByte() {
+        return buffer.readByte();
+    }
+
+    
+    public void readBytes(byte[] dst) {
+        buffer.readBytes(dst);
+    }
+
+    
+    public void readBytes(byte[] dst, int dstIndex, int length) {
+        buffer.readBytes(dst, dstIndex, length);
+    }
+
+    
+    public void readBytes(ByteBuffer dst) {
+        buffer.readBytes(dst);
+    }
+
+    
+    public void readBytes(ChannelBuffer dst) {
+        // careful
+        readBytes(dst, dst.writableBytes());
+    }
+
+    
+    public void readBytes(ChannelBuffer dst, int length) {
+        // carefule
+        if (length > dst.writableBytes()) {
+            throw new IndexOutOfBoundsException();
+        }
+        readBytes(dst, dst.writerIndex(), length);
+        dst.writerIndex(dst.writerIndex() + length);
+    }
+
+    
+    public void readBytes(ChannelBuffer dst, int dstIndex, int length) {
+        // careful
+        if (readableBytes() < length) {
+            throw new IndexOutOfBoundsException();
+        }
+        byte[] data = new byte[length];
+        buffer.readBytes(data, 0, length);
+        dst.setBytes(dstIndex, data, 0, length);
+    }
+
+    
+    public ChannelBuffer readBytes(int length) {
+        return new NettyBackedChannelBuffer(buffer.readBytes(length));
+    }
+
+    
+    public void resetReaderIndex() {
+        buffer.resetReaderIndex();
+    }
+
+    
+    public void resetWriterIndex() {
+        buffer.resetWriterIndex();
+    }
+
+    
+    public int readerIndex() {
+        return buffer.readerIndex();
+    }
+
+    
+    public void readerIndex(int readerIndex) {
+        buffer.readerIndex(readerIndex);
+    }
+
+    
+    public void readBytes(OutputStream dst, int length) throws IOException {
+        buffer.readBytes(dst, length);
+    }
+
+    
+    public void setBytes(int index, byte[] src) {
+        buffer.setBytes(index, src);
+    }
+
+    
+    public void setBytes(int index, ChannelBuffer src) {
+        // careful
+        setBytes(index, src, src.readableBytes());
+    }
+
+    
+    public void setBytes(int index, ChannelBuffer src, int length) {
+        // careful
+        if (length > src.readableBytes()) {
+            throw new IndexOutOfBoundsException();
+        }
+        setBytes(index, src, src.readerIndex(), length);
+        src.readerIndex(src.readerIndex() + length);
+    }
+
+    
+    public void setIndex(int readerIndex, int writerIndex) {
+        buffer.setIndex(readerIndex, writerIndex);
+    }
+
+    
+    public void skipBytes(int length) {
+        buffer.skipBytes(length);
+    }
+
+    
+    public ByteBuffer toByteBuffer() {
+        return buffer.nioBuffer();
+    }
+
+    
+    public boolean writable() {
+        return buffer.isWritable();
+    }
+
+    
+    public int writableBytes() {
+        return buffer.writableBytes();
+    }
+
+    
+    public void writeByte(int value) {
+        buffer.writeByte(value);
+    }
+
+    
+    public void writeBytes(byte[] src) {
+        buffer.writeBytes(src);
+    }
+
+    
+    public void writeBytes(byte[] src, int index, int length) {
+        buffer.writeBytes(src, index, length);
+    }
+
+    
+    public void writeBytes(ByteBuffer src) {
+        buffer.writeBytes(src);
+    }
+
+    
+    public void writeBytes(ChannelBuffer src) {
+        // careful
+        writeBytes(src, src.readableBytes());
+    }
+
+    
+    public void writeBytes(ChannelBuffer src, int length) {
+        // careful
+        if (length > src.readableBytes()) {
+            throw new IndexOutOfBoundsException();
+        }
+        writeBytes(src, src.readerIndex(), length);
+        src.readerIndex(src.readerIndex() + length);
+    }
+
+    
+    public void writeBytes(ChannelBuffer src, int srcIndex, int length) {
+        // careful
+        byte[] data = new byte[length];
+        src.getBytes(srcIndex, data, 0, length);
+        writeBytes(data, 0, length);
+    }
+
+    
+    public int writeBytes(InputStream src, int length) throws IOException {
+        return buffer.writeBytes(src, length);
+    }
+
+    
+    public int writerIndex() {
+        return buffer.writerIndex();
+    }
+
+    
+    public void writerIndex(int writerIndex) {
+        buffer.writerIndex(writerIndex);
+    }
+
+    
+    public int compareTo(ChannelBuffer o) {
+        return ChannelBuffers.compare(this, o);
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyChannel.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.remoting.transport.netty4;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
+import com.alibaba.dubbo.remoting.ChannelHandler;
+import com.alibaba.dubbo.remoting.RemotingException;
+import com.alibaba.dubbo.remoting.transport.AbstractChannel;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * NettyChannel.
+ *
+ * @author qian.lei
+ * @author william.liangf
+ * @author qinliujie
+ */
+final class NettyChannel extends AbstractChannel {
+
+    private static final Logger logger = LoggerFactory.getLogger(NettyChannel.class);
+
+    private static final ConcurrentMap<Channel, NettyChannel> channelMap = new ConcurrentHashMap<Channel, NettyChannel>();
+
+    private final Channel channel;
+
+    private final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();
+
+    private NettyChannel(Channel channel, URL url, ChannelHandler handler) {
+        super(url, handler);
+        if (channel == null) {
+            throw new IllegalArgumentException("netty channel == null;");
+        }
+        this.channel = channel;
+    }
+
+    static NettyChannel getOrAddChannel(Channel ch, URL url, ChannelHandler handler) {
+        if (ch == null) {
+            return null;
+        }
+        NettyChannel ret = channelMap.get(ch);
+        if (ret == null) {
+            NettyChannel nettyChannel = new NettyChannel(ch, url, handler);
+            if (ch.isActive()) {
+                ret = channelMap.putIfAbsent(ch, nettyChannel);
+            }
+            if (ret == null) {
+                ret = nettyChannel;
+            }
+        }
+        return ret;
+    }
+
+    static void removeChannelIfDisconnected(Channel ch) {
+        if (ch != null && !ch.isActive()) {
+            channelMap.remove(ch);
+        }
+    }
+
+    public InetSocketAddress getLocalAddress() {
+        return (InetSocketAddress) channel.localAddress();
+    }
+
+    public InetSocketAddress getRemoteAddress() {
+        return (InetSocketAddress) channel.remoteAddress();
+    }
+
+    public boolean isConnected() {
+        return channel.isActive();
+    }
+
+    public void send(Object message, boolean sent) throws RemotingException {
+        super.send(message, sent);
+
+        boolean success = true;
+        int timeout = 0;
+        try {
+            ChannelFuture future = channel.writeAndFlush(message);
+            if (sent) {
+                timeout = getUrl().getPositiveParameter(Constants.TIMEOUT_KEY, Constants.DEFAULT_TIMEOUT);
+                success = future.await(timeout);
+            }
+            Throwable cause = future.cause();
+            if (cause != null) {
+                throw cause;
+            }
+        } catch (Throwable e) {
+            throw new RemotingException(this, "Failed to send message " + message + " to " + getRemoteAddress() + ", cause: " + e.getMessage(), e);
+        }
+
+        if (!success) {
+            throw new RemotingException(this, "Failed to send message " + message + " to " + getRemoteAddress()
+                    + "in timeout(" + timeout + "ms) limit");
+        }
+    }
+
+    public void close() {
+        try {
+            super.close();
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+        }
+        try {
+            removeChannelIfDisconnected(channel);
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+        }
+        try {
+            attributes.clear();
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+        }
+        try {
+            if (logger.isInfoEnabled()) {
+                logger.info("Close netty channel " + channel);
+            }
+            channel.close();
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+        }
+    }
+
+    public boolean hasAttribute(String key) {
+        return attributes.containsKey(key);
+    }
+
+    public Object getAttribute(String key) {
+        return attributes.get(key);
+    }
+
+    public void setAttribute(String key, Object value) {
+        if (value == null) { // The null value unallowed in the ConcurrentHashMap.
+            attributes.remove(key);
+        } else {
+            attributes.put(key, value);
+        }
+    }
+
+    public void removeAttribute(String key) {
+        attributes.remove(key);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((channel == null) ? 0 : channel.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        NettyChannel other = (NettyChannel) obj;
+        if (channel == null) {
+            if (other.channel != null) return false;
+        } else if (!channel.equals(other.channel)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "NettyChannel [channel=" + channel + "]";
+    }
+
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyClient.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.remoting.transport.netty4;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.Version;
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
+import com.alibaba.dubbo.common.utils.NetUtils;
+import com.alibaba.dubbo.remoting.ChannelHandler;
+import com.alibaba.dubbo.remoting.RemotingException;
+import com.alibaba.dubbo.remoting.transport.AbstractClient;
+import com.alibaba.dubbo.remoting.transport.netty4.logging.NettyHelper;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * NettyClient.
+ *
+ * @author qian.lei
+ * @author william.liangf
+ * @author qinliujie
+ */
+public class NettyClient extends AbstractClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(NettyClient.class);
+
+    private static final NioEventLoopGroup nioEventLoopGroup = new NioEventLoopGroup(Constants.DEFAULT_IO_THREADS, new DefaultThreadFactory("NettyClientWorker", true));
+
+    private Bootstrap bootstrap;
+
+    private volatile Channel channel; // volatile, please copy reference to use
+
+    public NettyClient(final URL url, final ChannelHandler handler) throws RemotingException {
+        super(url, wrapChannelHandler(url, handler));
+    }
+
+    @Override
+    protected void doOpen() throws Throwable {
+        NettyHelper.setNettyLoggerFactory();
+        final NettyClientHandler nettyClientHandler = new NettyClientHandler(getUrl(), this);
+        bootstrap = new Bootstrap();
+        bootstrap.group(nioEventLoopGroup)
+                .option(ChannelOption.SO_KEEPALIVE, true)
+                .option(ChannelOption.TCP_NODELAY, true)
+                .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+                //.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getTimeout())
+                .channel(NioSocketChannel.class);
+
+        if (getTimeout() < 3000) {
+            bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000);
+        } else {
+            bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getTimeout());
+        }
+
+        bootstrap.handler(new ChannelInitializer() {
+
+            protected void initChannel(Channel ch) throws Exception {
+                NettyCodecAdapter adapter = new NettyCodecAdapter(getCodec(), getUrl(), NettyClient.this);
+                ch.pipeline()//.addLast("logging",new LoggingHandler(LogLevel.INFO))//for debug
+                        .addLast("decoder", adapter.getDecoder())//
+                        .addLast("encoder", adapter.getEncoder())//
+                        .addLast("handler", nettyClientHandler);
+            }
+        });
+    }
+
+    protected void doConnect() throws Throwable {
+        long start = System.currentTimeMillis();
+        ChannelFuture future = bootstrap.connect(getConnectAddress());
+        try {
+            boolean ret = future.awaitUninterruptibly(3000, TimeUnit.MILLISECONDS);
+
+            if (ret && future.isSuccess()) {
+                Channel newChannel = future.channel();
+                try {
+                    // 关闭旧的连接
+                    Channel oldChannel = NettyClient.this.channel; // copy reference
+                    if (oldChannel != null) {
+                        try {
+                            if (logger.isInfoEnabled()) {
+                                logger.info("Close old netty channel " + oldChannel + " on create new netty channel " + newChannel);
+                            }
+                            oldChannel.close();
+                        } finally {
+                            NettyChannel.removeChannelIfDisconnected(oldChannel);
+                        }
+                    }
+                } finally {
+                    if (NettyClient.this.isClosed()) {
+                        try {
+                            if (logger.isInfoEnabled()) {
+                                logger.info("Close new netty channel " + newChannel + ", because the client closed.");
+                            }
+                            newChannel.close();
+                        } finally {
+                            NettyClient.this.channel = null;
+                            NettyChannel.removeChannelIfDisconnected(newChannel);
+                        }
+                    } else {
+                        NettyClient.this.channel = newChannel;
+                    }
+                }
+            } else if (future.cause() != null) {
+                throw new RemotingException(this, "client(url: " + getUrl() + ") failed to connect to server "
+                        + getRemoteAddress() + ", error message is:" + future.cause().getMessage(), future.cause());
+            } else {
+                throw new RemotingException(this, "client(url: " + getUrl() + ") failed to connect to server "
+                        + getRemoteAddress() + " client-side timeout "
+                        + getConnectTimeout() + "ms (elapsed: " + (System.currentTimeMillis() - start) + "ms) from netty client "
+                        + NetUtils.getLocalHost() + " using dubbo version " + Version.getVersion());
+            }
+        } finally {
+            if (!isConnected()) {
+                //future.cancel(true);
+            }
+        }
+    }
+
+    @Override
+    protected void doDisConnect() throws Throwable {
+        try {
+            NettyChannel.removeChannelIfDisconnected(channel);
+        } catch (Throwable t) {
+            logger.warn(t.getMessage());
+        }
+    }
+
+    @Override
+    protected void doClose() throws Throwable {
+        //can't shutdown nioEventLoopGroup
+        //nioEventLoopGroup.shutdownGracefully();
+    }
+
+    @Override
+    protected com.alibaba.dubbo.remoting.Channel getChannel() {
+        Channel c = channel;
+        if (c == null || !c.isActive())
+            return null;
+        return NettyChannel.getOrAddChannel(c, getUrl(), this);
+    }
+
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyClientHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyClientHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.remoting.transport.netty4;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.remoting.ChannelHandler;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+/**
+ * NettyClientHandler
+ *
+ * @author william.liangf
+ * @author qinliujie
+ */
+@io.netty.channel.ChannelHandler.Sharable
+public class NettyClientHandler extends ChannelDuplexHandler {
+
+    private final URL url;
+
+    private final ChannelHandler handler;
+
+    public NettyClientHandler(URL url, ChannelHandler handler) {
+        if (url == null) {
+            throw new IllegalArgumentException("url == null");
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("handler == null");
+        }
+        this.url = url;
+        this.handler = handler;
+    }
+
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelActive();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelInactive();
+    }
+
+    @Override
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise future)
+            throws Exception {
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            handler.disconnected(channel);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            handler.received(channel, msg);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        super.write(ctx, msg, promise);
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            handler.sent(channel, msg);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+            throws Exception {
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            handler.caught(channel, cause);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyCodecAdapter.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyCodecAdapter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.remoting.transport.netty4;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.remoting.Codec2;
+import com.alibaba.dubbo.remoting.buffer.ChannelBuffer;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * NettyCodecAdapter.
+ * 
+ * @author qian.lei
+ * @author qinliujie
+ */
+final class NettyCodecAdapter {
+
+    private final ChannelHandler encoder = new InternalEncoder();
+    
+    private final ChannelHandler decoder = new InternalDecoder();
+
+    private final Codec2         codec;
+    
+    private final URL            url;
+    
+    private final com.alibaba.dubbo.remoting.ChannelHandler handler;
+
+    public NettyCodecAdapter(Codec2 codec, URL url, com.alibaba.dubbo.remoting.ChannelHandler handler) {
+        this.codec = codec;
+        this.url = url;
+        this.handler = handler;
+    }
+
+    public ChannelHandler getEncoder() {
+        return encoder;
+    }
+
+    public ChannelHandler getDecoder() {
+        return decoder;
+    }
+
+    private class InternalEncoder extends MessageToByteEncoder {
+
+        protected void encode(ChannelHandlerContext ctx, Object msg, ByteBuf out) throws Exception {
+            com.alibaba.dubbo.remoting.buffer.ChannelBuffer buffer = new NettyBackedChannelBuffer(out);
+            Channel ch = ctx.channel();
+            NettyChannel channel = NettyChannel.getOrAddChannel(ch, url, handler);
+            try {
+                codec.encode(channel, buffer, msg);
+            } finally {
+                NettyChannel.removeChannelIfDisconnected(ch);
+            }
+        }
+    }
+
+    private class InternalDecoder extends ByteToMessageDecoder {
+
+        protected void decode(ChannelHandlerContext ctx, ByteBuf input, List<Object> out) throws Exception {
+
+            ChannelBuffer message = new NettyBackedChannelBuffer(input);
+
+            NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+
+            Object msg;
+
+            int saveReaderIndex;
+
+            try {
+                // decode object.
+                do {
+                    saveReaderIndex = message.readerIndex();
+                    try {
+                        msg = codec.decode(channel, message);
+                    } catch (IOException e) {
+                        throw e;
+                    }
+                    if (msg == Codec2.DecodeResult.NEED_MORE_INPUT) {
+                        message.readerIndex(saveReaderIndex);
+                        break;
+                    } else {
+                        //is it possible to go here ?
+                        if (saveReaderIndex == message.readerIndex()) {
+                            throw new IOException("Decode without read data.");
+                        }
+                        if (msg != null) {
+                            out.add(msg);
+                        }
+                    }
+                } while (message.readable());
+            } finally {
+                NettyChannel.removeChannelIfDisconnected(ctx.channel());
+            }
+        }
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyServer.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyServer.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.remoting.transport.netty4;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
+import com.alibaba.dubbo.common.utils.ExecutorUtil;
+import com.alibaba.dubbo.common.utils.NetUtils;
+import com.alibaba.dubbo.remoting.Channel;
+import com.alibaba.dubbo.remoting.ChannelHandler;
+import com.alibaba.dubbo.remoting.RemotingException;
+import com.alibaba.dubbo.remoting.Server;
+import com.alibaba.dubbo.remoting.transport.AbstractServer;
+import com.alibaba.dubbo.remoting.transport.dispatcher.ChannelHandlers;
+import com.alibaba.dubbo.remoting.transport.netty4.logging.NettyHelper;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * NettyServer
+ *
+ * @author qian.lei
+ * @author chao.liuc
+ * @author qinliujie
+ */
+public class NettyServer extends AbstractServer implements Server {
+
+    private static final Logger logger = LoggerFactory.getLogger(NettyServer.class);
+
+    private Map<String, Channel> channels; // <ip:port, channel>
+
+    private ServerBootstrap bootstrap;
+
+    private io.netty.channel.Channel channel;
+
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+
+    public NettyServer(URL url, ChannelHandler handler) throws RemotingException {
+        super(url, ChannelHandlers.wrap(handler, ExecutorUtil.setThreadName(url, SERVER_THREAD_POOL_NAME)));
+    }
+
+    @Override
+    protected void doOpen() throws Throwable {
+        NettyHelper.setNettyLoggerFactory();
+
+        bootstrap = new ServerBootstrap();
+
+        bossGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("NettyServerBoss", true));
+        workerGroup = new NioEventLoopGroup(getUrl().getPositiveParameter(Constants.IO_THREADS_KEY, Constants.DEFAULT_IO_THREADS),
+                new DefaultThreadFactory("NettyServerWorker", true));
+
+        final NettyServerHandler nettyServerHandler = new NettyServerHandler(getUrl(), this);
+        channels = nettyServerHandler.getChannels();
+
+        bootstrap.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .childOption(ChannelOption.TCP_NODELAY, Boolean.TRUE)
+                .childOption(ChannelOption.SO_REUSEADDR, Boolean.TRUE)
+                .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+                .childHandler(new ChannelInitializer<NioSocketChannel>() {
+                    @Override
+                    protected void initChannel(NioSocketChannel ch) throws Exception {
+                        NettyCodecAdapter adapter = new NettyCodecAdapter(getCodec(), getUrl(), NettyServer.this);
+                        ch.pipeline()//.addLast("logging",new LoggingHandler(LogLevel.INFO))//for debug
+                                .addLast("decoder", adapter.getDecoder())
+                                .addLast("encoder", adapter.getEncoder())
+                                .addLast("handler", nettyServerHandler);
+                    }
+                });
+        // bind
+        ChannelFuture channelFuture = bootstrap.bind(getBindAddress());
+        channelFuture.syncUninterruptibly();
+        channel = channelFuture.channel();
+
+    }
+
+    @Override
+    protected void doClose() throws Throwable {
+        try {
+            if (channel != null) {
+                // unbind.
+                channel.close();
+            }
+        } catch (Throwable e) {
+            logger.warn(e.getMessage(), e);
+        }
+        try {
+            Collection<com.alibaba.dubbo.remoting.Channel> channels = getChannels();
+            if (channels != null && channels.size() > 0) {
+                for (com.alibaba.dubbo.remoting.Channel channel : channels) {
+                    try {
+                        channel.close();
+                    } catch (Throwable e) {
+                        logger.warn(e.getMessage(), e);
+                    }
+                }
+            }
+        } catch (Throwable e) {
+            logger.warn(e.getMessage(), e);
+        }
+        try {
+            if (bootstrap != null) {
+                bossGroup.shutdownGracefully();
+                workerGroup.shutdownGracefully();
+            }
+        } catch (Throwable e) {
+            logger.warn(e.getMessage(), e);
+        }
+        try {
+            if (channels != null) {
+                channels.clear();
+            }
+        } catch (Throwable e) {
+            logger.warn(e.getMessage(), e);
+        }
+    }
+
+    public Collection<Channel> getChannels() {
+        Collection<Channel> chs = new HashSet<Channel>();
+        for (Channel channel : this.channels.values()) {
+            if (channel.isConnected()) {
+                chs.add(channel);
+            } else {
+                channels.remove(NetUtils.toAddressString(channel.getRemoteAddress()));
+            }
+        }
+        return chs;
+    }
+
+    public Channel getChannel(InetSocketAddress remoteAddress) {
+        return channels.get(NetUtils.toAddressString(remoteAddress));
+    }
+
+    public boolean isBound() {
+        return channel.isActive();
+    }
+
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyServerHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyServerHandler.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.remoting.transport.netty4;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.utils.NetUtils;
+import com.alibaba.dubbo.remoting.Channel;
+import com.alibaba.dubbo.remoting.ChannelHandler;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * NettyClientHandler
+ *
+ * @author william.liangf
+ * @author qinliujie
+ */
+@io.netty.channel.ChannelHandler.Sharable
+public class NettyServerHandler extends ChannelDuplexHandler {
+
+    private final Map<String, Channel> channels = new ConcurrentHashMap<String, Channel>(); // <ip:port, channel>
+
+    private final URL url;
+
+    private final ChannelHandler handler;
+
+    public NettyServerHandler(URL url, ChannelHandler handler) {
+        if (url == null) {
+            throw new IllegalArgumentException("url == null");
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("handler == null");
+        }
+        this.url = url;
+        this.handler = handler;
+    }
+
+    public Map<String, Channel> getChannels() {
+        return channels;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelActive();
+
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            if (channel != null) {
+                channels.put(NetUtils.toAddressString((InetSocketAddress)ctx.channel().remoteAddress()), channel);
+            }
+            handler.connected(channel);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            channels.remove(NetUtils.toAddressString((InetSocketAddress) ctx.channel().remoteAddress()));
+            handler.disconnected(channel);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+
+
+    @Override
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise future)
+            throws Exception {
+
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            handler.received(channel, msg);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        super.write(ctx, msg, promise);
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            handler.sent(channel, msg);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+            throws Exception {
+        NettyChannel channel = NettyChannel.getOrAddChannel(ctx.channel(), url, handler);
+        try {
+            handler.caught(channel, cause);
+        } finally {
+            NettyChannel.removeChannelIfDisconnected(ctx.channel());
+        }
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyTransporter.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyTransporter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.remoting.transport.netty4;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.remoting.ChannelHandler;
+import com.alibaba.dubbo.remoting.Client;
+import com.alibaba.dubbo.remoting.RemotingException;
+import com.alibaba.dubbo.remoting.Server;
+import com.alibaba.dubbo.remoting.Transporter;
+
+/**
+ * @author ding.lid
+ * @author qinliujie
+ */
+public class NettyTransporter implements Transporter {
+
+    public static final String NAME = "netty4";
+    
+    public Server bind(URL url, ChannelHandler listener) throws RemotingException {
+        return new NettyServer(url, listener);
+    }
+
+    public Client connect(URL url, ChannelHandler listener) throws RemotingException {
+        return new NettyClient(url, listener);
+    }
+
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/FormattingTuple.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/FormattingTuple.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.alibaba.dubbo.remoting.transport.netty4.logging;
+
+
+/**
+ * Holds the results of formatting done by {@link MessageFormatter}.
+ */
+class FormattingTuple {
+
+    static final FormattingTuple NULL = new FormattingTuple(null);
+
+    private final String message;
+    private final Throwable throwable;
+    private final Object[] argArray;
+
+    FormattingTuple(String message) {
+        this(message, null, null);
+    }
+
+    FormattingTuple(String message, Object[] argArray, Throwable throwable) {
+        this.message = message;
+        this.throwable = throwable;
+        if (throwable == null) {
+            this.argArray = argArray;
+        } else {
+            this.argArray = trimmedCopy(argArray);
+        }
+    }
+
+    static Object[] trimmedCopy(Object[] argArray) {
+        if (argArray == null || argArray.length == 0) {
+            throw new IllegalStateException("non-sensical empty or null argument array");
+        }
+        final int trimemdLen = argArray.length - 1;
+        Object[] trimmed = new Object[trimemdLen];
+        System.arraycopy(argArray, 0, trimmed, 0, trimemdLen);
+        return trimmed;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Object[] getArgArray() {
+        return argArray;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/MessageFormatter.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/MessageFormatter.java
@@ -1,0 +1,390 @@
+package com.alibaba.dubbo.remoting.transport.netty4.logging;
+
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+// contributors: lizongbo: proposed special treatment of array parameter values
+// Joern Huxhorn: pointed out double[] omission, suggested deep array copy
+
+/**
+ * Formats messages according to very simple substitution rules. Substitutions
+ * can be made 1, 2 or more arguments.
+ * <p/>
+ * <p/>
+ * For example,
+ * <p/>
+ * <pre>
+ * MessageFormatter.format(&quot;Hi {}.&quot;, &quot;there&quot;)
+ * </pre>
+ * <p/>
+ * will return the string "Hi there.".
+ * <p/>
+ * The {} pair is called the <em>formatting anchor</em>. It serves to designate
+ * the location where arguments need to be substituted within the message
+ * pattern.
+ * <p/>
+ * In case your message contains the '{' or the '}' character, you do not have
+ * to do anything special unless the '}' character immediately follows '{'. For
+ * example,
+ * <p/>
+ * <pre>
+ * MessageFormatter.format(&quot;Set {1,2,3} is not equal to {}.&quot;, &quot;1,2&quot;);
+ * </pre>
+ * <p/>
+ * will return the string "Set {1,2,3} is not equal to 1,2.".
+ * <p/>
+ * <p/>
+ * If for whatever reason you need to place the string "{}" in the message
+ * without its <em>formatting anchor</em> meaning, then you need to escape the
+ * '{' character with '\', that is the backslash character. Only the '{'
+ * character should be escaped. There is no need to escape the '}' character.
+ * For example,
+ * <p/>
+ * <pre>
+ * MessageFormatter.format(&quot;Set \\{} is not equal to {}.&quot;, &quot;1,2&quot;);
+ * </pre>
+ * <p/>
+ * will return the string "Set {} is not equal to 1,2.".
+ * <p/>
+ * <p/>
+ * The escaping behavior just described can be overridden by escaping the escape
+ * character '\'. Calling
+ * <p/>
+ * <pre>
+ * MessageFormatter.format(&quot;File name is C:\\\\{}.&quot;, &quot;file.zip&quot;);
+ * </pre>
+ * <p/>
+ * will return the string "File name is C:\file.zip".
+ * <p/>
+ * <p/>
+ * The formatting conventions are different than those of {@link MessageFormat}
+ * which ships with the Java platform. This is justified by the fact that
+ * SLF4J's implementation is 10 times faster than that of {@link MessageFormat}.
+ * This local performance difference is both measurable and significant in the
+ * larger context of the complete logging processing chain.
+ * <p/>
+ * <p/>
+ * See also {@link #format(String, Object)},
+ * {@link #format(String, Object, Object)} and
+ * {@link #arrayFormat(String, Object[])} methods for more details.
+ */
+final class MessageFormatter {
+    static final char DELIM_START = '{';
+    static final char DELIM_STOP = '}';
+    static final String DELIM_STR = "{}";
+    private static final char ESCAPE_CHAR = '\\';
+
+    /**
+     * Performs single argument substitution for the 'messagePattern' passed as
+     * parameter.
+     * <p/>
+     * For example,
+     * <p/>
+     * <pre>
+     * MessageFormatter.format(&quot;Hi {}.&quot;, &quot;there&quot;);
+     * </pre>
+     * <p/>
+     * will return the string "Hi there.".
+     * <p/>
+     *
+     * @param messagePattern The message pattern which will be parsed and formatted
+     * @param arg            The argument to be substituted in place of the formatting anchor
+     * @return The formatted message
+     */
+    static FormattingTuple format(String messagePattern, Object arg) {
+        return arrayFormat(messagePattern, new Object[]{arg});
+    }
+
+    /**
+     * Performs a two argument substitution for the 'messagePattern' passed as
+     * parameter.
+     * <p/>
+     * For example,
+     * <p/>
+     * <pre>
+     * MessageFormatter.format(&quot;Hi {}. My name is {}.&quot;, &quot;Alice&quot;, &quot;Bob&quot;);
+     * </pre>
+     * <p/>
+     * will return the string "Hi Alice. My name is Bob.".
+     *
+     * @param messagePattern The message pattern which will be parsed and formatted
+     * @param argA           The argument to be substituted in place of the first formatting
+     *                       anchor
+     * @param argB           The argument to be substituted in place of the second formatting
+     *                       anchor
+     * @return The formatted message
+     */
+    static FormattingTuple format(final String messagePattern,
+                                  Object argA, Object argB) {
+        return arrayFormat(messagePattern, new Object[]{argA, argB});
+    }
+
+    static Throwable getThrowableCandidate(Object[] argArray) {
+        if (argArray == null || argArray.length == 0) {
+            return null;
+        }
+
+        final Object lastEntry = argArray[argArray.length - 1];
+        if (lastEntry instanceof Throwable) {
+            return (Throwable) lastEntry;
+        }
+        return null;
+    }
+
+    /**
+     * Same principle as the {@link #format(String, Object)} and
+     * {@link #format(String, Object, Object)} methods except that any number of
+     * arguments can be passed in an array.
+     *
+     * @param messagePattern The message pattern which will be parsed and formatted
+     * @param argArray       An array of arguments to be substituted in place of formatting
+     *                       anchors
+     * @return The formatted message
+     */
+    static FormattingTuple arrayFormat(final String messagePattern,
+                                       final Object[] argArray) {
+
+        Throwable throwableCandidate = getThrowableCandidate(argArray);
+
+        if (messagePattern == null) {
+            return new FormattingTuple(null, argArray, throwableCandidate);
+        }
+
+        if (argArray == null) {
+            return new FormattingTuple(messagePattern);
+        }
+
+        int i = 0;
+        int j;
+        StringBuffer sbuf = new StringBuffer(messagePattern.length() + 50);
+
+        int L;
+        for (L = 0; L < argArray.length; L++) {
+
+            j = messagePattern.indexOf(DELIM_STR, i);
+
+            if (j == -1) {
+                // no more variables
+                if (i == 0) { // this is a simple string
+                    return new FormattingTuple(messagePattern, argArray,
+                            throwableCandidate);
+                } else { // add the tail string which contains no variables and return
+                    // the result.
+                    sbuf.append(messagePattern.substring(i, messagePattern.length()));
+                    return new FormattingTuple(sbuf.toString(), argArray,
+                            throwableCandidate);
+                }
+            } else {
+                if (isEscapedDelimeter(messagePattern, j)) {
+                    if (!isDoubleEscaped(messagePattern, j)) {
+                        L--; // DELIM_START was escaped, thus should not be incremented
+                        sbuf.append(messagePattern.substring(i, j - 1));
+                        sbuf.append(DELIM_START);
+                        i = j + 1;
+                    } else {
+                        // The escape character preceding the delimiter start is
+                        // itself escaped: "abc x:\\{}"
+                        // we have to consume one backward slash
+                        sbuf.append(messagePattern.substring(i, j - 1));
+                        deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Void>());
+                        i = j + 2;
+                    }
+                } else {
+                    // normal case
+                    sbuf.append(messagePattern.substring(i, j));
+                    deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Void>());
+                    i = j + 2;
+                }
+            }
+        }
+        // append the characters following the last {} pair.
+        sbuf.append(messagePattern.substring(i, messagePattern.length()));
+        if (L < argArray.length - 1) {
+            return new FormattingTuple(sbuf.toString(), argArray, throwableCandidate);
+        } else {
+            return new FormattingTuple(sbuf.toString(), argArray, null);
+        }
+    }
+
+    static boolean isEscapedDelimeter(String messagePattern,
+                                      int delimeterStartIndex) {
+
+        if (delimeterStartIndex == 0) {
+            return false;
+        }
+        return messagePattern.charAt(delimeterStartIndex - 1) == ESCAPE_CHAR;
+    }
+
+    static boolean isDoubleEscaped(String messagePattern,
+                                   int delimeterStartIndex) {
+        return delimeterStartIndex >= 2 && messagePattern.charAt(delimeterStartIndex - 2) == ESCAPE_CHAR;
+    }
+
+    // special treatment of array values was suggested by 'lizongbo'
+    private static void deeplyAppendParameter(StringBuffer sbuf, Object o,
+                                              Map<Object[], Void> seenMap) {
+        if (o == null) {
+            sbuf.append("null");
+            return;
+        }
+        if (!o.getClass().isArray()) {
+            safeObjectAppend(sbuf, o);
+        } else {
+            // check for primitive array types because they
+            // unfortunately cannot be cast to Object[]
+            if (o instanceof boolean[]) {
+                booleanArrayAppend(sbuf, (boolean[]) o);
+            } else if (o instanceof byte[]) {
+                byteArrayAppend(sbuf, (byte[]) o);
+            } else if (o instanceof char[]) {
+                charArrayAppend(sbuf, (char[]) o);
+            } else if (o instanceof short[]) {
+                shortArrayAppend(sbuf, (short[]) o);
+            } else if (o instanceof int[]) {
+                intArrayAppend(sbuf, (int[]) o);
+            } else if (o instanceof long[]) {
+                longArrayAppend(sbuf, (long[]) o);
+            } else if (o instanceof float[]) {
+                floatArrayAppend(sbuf, (float[]) o);
+            } else if (o instanceof double[]) {
+                doubleArrayAppend(sbuf, (double[]) o);
+            } else {
+                objectArrayAppend(sbuf, (Object[]) o, seenMap);
+            }
+        }
+    }
+
+    private static void safeObjectAppend(StringBuffer sbuf, Object o) {
+        try {
+            String oAsString = o.toString();
+            sbuf.append(oAsString);
+        } catch (Throwable t) {
+            System.err
+                    .println("SLF4J: Failed toString() invocation on an object of type ["
+                            + o.getClass().getName() + ']');
+            t.printStackTrace();
+            sbuf.append("[FAILED toString()]");
+        }
+    }
+
+    private static void objectArrayAppend(StringBuffer sbuf, Object[] a,
+                                          Map<Object[], Void> seenMap) {
+        sbuf.append('[');
+        if (!seenMap.containsKey(a)) {
+            seenMap.put(a, null);
+            final int len = a.length;
+            for (int i = 0; i < len; i++) {
+                deeplyAppendParameter(sbuf, a[i], seenMap);
+                if (i != len - 1) {
+                    sbuf.append(", ");
+                }
+            }
+            // allow repeats in siblings
+            seenMap.remove(a);
+        } else {
+            sbuf.append("...");
+        }
+        sbuf.append(']');
+    }
+
+    private static void booleanArrayAppend(StringBuffer sbuf, boolean[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1) {
+                sbuf.append(", ");
+            }
+        }
+        sbuf.append(']');
+    }
+
+    private static void byteArrayAppend(StringBuffer sbuf, byte[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1) {
+                sbuf.append(", ");
+            }
+        }
+        sbuf.append(']');
+    }
+
+    private static void charArrayAppend(StringBuffer sbuf, char[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1) {
+                sbuf.append(", ");
+            }
+        }
+        sbuf.append(']');
+    }
+
+    private static void shortArrayAppend(StringBuffer sbuf, short[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1) {
+                sbuf.append(", ");
+            }
+        }
+        sbuf.append(']');
+    }
+
+    private static void intArrayAppend(StringBuffer sbuf, int[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1) {
+                sbuf.append(", ");
+            }
+        }
+        sbuf.append(']');
+    }
+
+    private static void longArrayAppend(StringBuffer sbuf, long[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1) {
+                sbuf.append(", ");
+            }
+        }
+        sbuf.append(']');
+    }
+
+    private static void floatArrayAppend(StringBuffer sbuf, float[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1) {
+                sbuf.append(", ");
+            }
+        }
+        sbuf.append(']');
+    }
+
+    private static void doubleArrayAppend(StringBuffer sbuf, double[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1) {
+                sbuf.append(", ");
+            }
+        }
+        sbuf.append(']');
+    }
+
+    private MessageFormatter() {
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/NettyHelper.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/NettyHelper.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.remoting.transport.netty4.logging;
+
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
+import io.netty.util.internal.logging.AbstractInternalLogger;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+/**
+ * @author <a href="mailto:gang.lvg@taobao.com">kimi</a>
+ * @author <a href="mailto:liujie.qlj@alibaba-inc.com">qinliujie</a>
+ */
+public class NettyHelper {
+
+    public static void setNettyLoggerFactory() {
+        InternalLoggerFactory factory = InternalLoggerFactory.getDefaultFactory();
+        if (factory == null || !(factory instanceof DubboLoggerFactory)) {
+            InternalLoggerFactory.setDefaultFactory(new DubboLoggerFactory());
+        }
+    }
+
+    static class DubboLoggerFactory extends InternalLoggerFactory {
+
+        @Override
+        public InternalLogger newInstance(String name) {
+            return new DubboLogger(LoggerFactory.getLogger(name));
+        }
+    }
+
+    static class DubboLogger extends AbstractInternalLogger {
+
+        private Logger logger;
+
+        DubboLogger(Logger logger) {
+            super(logger.getClass().getName());
+            this.logger = logger;
+        }
+
+        public boolean isTraceEnabled() {
+            return logger.isTraceEnabled();
+        }
+
+        public void trace(String msg) {
+            if (isTraceEnabled()) {
+                logger.trace(msg);
+            }
+        }
+
+        public void trace(String format, Object arg) {
+            if (isTraceEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, arg);
+                logger.trace(ft.getMessage(), ft.getThrowable());
+            }
+
+        }
+
+        public void trace(String format, Object argA, Object argB) {
+            if (isTraceEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+                logger.trace(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void trace(String format, Object... arguments) {
+            if (isTraceEnabled()) {
+                FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
+                logger.trace(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void trace(String msg, Throwable t) {
+            if (isTraceEnabled()) {
+                logger.trace(msg, t);
+            }
+        }
+
+        public boolean isDebugEnabled() {
+            return logger.isDebugEnabled();
+        }
+
+        public void debug(String msg) {
+            if (isDebugEnabled()) {
+                logger.debug(msg);
+            }
+        }
+
+        public void debug(String format, Object arg) {
+            if (isDebugEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, arg);
+                logger.debug(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void debug(String format, Object argA, Object argB) {
+            if (isDebugEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+                logger.debug(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void debug(String format, Object... arguments) {
+            if (isDebugEnabled()) {
+                FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
+                logger.debug(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void debug(String msg, Throwable t) {
+            if (isDebugEnabled()) {
+                logger.debug(msg, t);
+            }
+        }
+
+        public boolean isInfoEnabled() {
+            return logger.isInfoEnabled();
+        }
+
+        public void info(String msg) {
+            if (isInfoEnabled()) {
+                logger.info(msg);
+            }
+        }
+
+        public void info(String format, Object arg) {
+            if (isInfoEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, arg);
+                logger.info(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void info(String format, Object argA, Object argB) {
+            if (isInfoEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+                logger.info(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void info(String format, Object... arguments) {
+            if (isInfoEnabled()) {
+                FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
+                logger.info(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void info(String msg, Throwable t) {
+            if (isInfoEnabled()) {
+                logger.info(msg, t);
+            }
+        }
+
+        public boolean isWarnEnabled() {
+            return false;
+        }
+
+        public void warn(String msg) {
+            if (isWarnEnabled()) {
+                logger.warn(msg);
+            }
+        }
+
+        public void warn(String format, Object arg) {
+            if (isWarnEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, arg);
+                logger.warn(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void warn(String format, Object... arguments) {
+            if (isWarnEnabled()) {
+                FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
+                logger.warn(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void warn(String format, Object argA, Object argB) {
+            if (isWarnEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+                logger.warn(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void warn(String msg, Throwable t) {
+            if (isWarnEnabled()) {
+                logger.warn(msg, t);
+            }
+        }
+
+        public boolean isErrorEnabled() {
+            return logger.isErrorEnabled();
+        }
+
+        public void error(String msg) {
+            if (isErrorEnabled()) {
+                logger.error(msg);
+            }
+        }
+
+        public void error(String format, Object arg) {
+            if (isErrorEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, arg);
+                logger.error(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void error(String format, Object argA, Object argB) {
+            if (isErrorEnabled()) {
+                FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+                logger.error(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void error(String format, Object... arguments) {
+            if (isErrorEnabled()) {
+                FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
+                logger.error(ft.getMessage(), ft.getThrowable());
+            }
+        }
+
+        public void error(String msg, Throwable t) {
+            if (isErrorEnabled()) {
+                logger.error(msg, t);
+            }
+        }
+    }
+
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.remoting.Transporter
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.remoting.Transporter
@@ -1,0 +1,1 @@
+netty4=com.alibaba.dubbo.remoting.transport.netty4.NettyTransporter

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/com/alibaba/AppTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/com/alibaba/AppTest.java
@@ -1,0 +1,38 @@
+package com.alibaba;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}

--- a/dubbo-remoting/pom.xml
+++ b/dubbo-remoting/pom.xml
@@ -37,5 +37,6 @@
         <module>dubbo-remoting-p2p</module>
         <module>dubbo-remoting-http</module>
         <module>dubbo-remoting-zookeeper</module>
+        <module>dubbo-remoting-netty4</module>
     </modules>
 </project>


### PR DESCRIPTION
原本只支持以clazz.getName() + "_" + toUpperMethoName(methodName)为分组的参数验证，现在增加在接口方法上的MethodValidated注解，可以有多个自定义的分组