### PR TITLE
路由优化

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/integration/RegistryDirectory.java
@@ -486,12 +486,13 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
                 invokersList.add(invoker);
             }
         }
-        newMethodInvokerMap.put(Constants.ANY_VALUE, invokersList);
+        List<Invoker<T>> newInvokersList = route(invokersList, null);
+        newMethodInvokerMap.put(Constants.ANY_VALUE, newInvokersList);
         if (serviceMethods != null && serviceMethods.length > 0) {
             for (String method : serviceMethods) {
                 List<Invoker<T>> methodInvokers = newMethodInvokerMap.get(method);
                 if (methodInvokers == null || methodInvokers.size() == 0) {
-                    methodInvokers = invokersList;
+                    methodInvokers = newInvokersList;
                 }
                 newMethodInvokerMap.put(method, route(methodInvokers, method));
             }


### PR DESCRIPTION
RegistryDirectory里面这段代码，完全可以先对invokers先做一遍route，因为不是所有路由策略都是方法级别的

之所以想改这个，是因为我们公司开发了一个api网关（基于dubbox的），是一个伪造的dubbo comsumer，也能用dubbo的服务发现，但是我本地类只是一个httpClient，代码上做了一些侵入性改造，执行到下面这段代码时serviceMethods这个变量是null，按照原来的逻辑只要serviceMethods为null，就不会做路由了，但是我希望至少支持service级别的路由