### PR TITLE
修复参数有泛型时类型转化出错

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/PojoUtils.java
@@ -412,12 +412,16 @@ public class PojoUtils {
                     Class<?> keyClazz;
                     if (keyType instanceof Class) {
                         keyClazz = (Class<?>) keyType;
+                    } else if (keyType instanceof ParameterizedType) {
+                        keyClazz = (Class<?>) ((ParameterizedType) keyType).getRawType();
                     } else {
                         keyClazz = entry.getKey() == null ? null : entry.getKey().getClass();
                     }
                     Class<?> valueClazz;
                     if (valueType instanceof Class) {
                         valueClazz = (Class<?>) valueType;
+                    } else if (valueType instanceof ParameterizedType) {
+                        valueClazz = (Class<?>) ((ParameterizedType) valueType).getRawType();
                     } else {
                         valueClazz = entry.getValue() == null ? null : entry.getValue().getClass();
                     }


### PR DESCRIPTION
当参数有泛型时，得到的参数类型不是Class类型而是ParameterizedType，则原代码会导致使用json反序列化后的类型，如果字段的实际参数与json反序列化默认参数不符的话将会报错，列入字段的类型为Set<XXX>，而json反序列化后的类型为List<XXX>