### PR TITLE
[^] 修改telnet测试 接口参数实现HashMap 导致 找不到方法问题。

### DIFF
--- a/dubbo-rpc/dubbo-rpc-default/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/InvokeTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-default/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/InvokeTelnetHandler.java
@@ -46,12 +46,21 @@ public class InvokeTelnetHandler implements TelnetHandler {
     private static Method findMethod(Exporter<?> exporter, String method, List<Object> args) {
         Invoker<?> invoker = exporter.getInvoker();
         Method[] methods = invoker.getInterface().getMethods();
+        Method invokeMethod = null;
         for (Method m : methods) {
-            if (m.getName().equals(method) && isMatch(m.getParameterTypes(), args)) {
-                return m;
+            if (m.getName().equals(method) && m.getParameterTypes().length == args.size()) {
+                if (invokeMethod != null) { // 重载
+                    if (isMatch(invokeMethod.getParameterTypes(), args)) {
+                        invokeMethod = m;
+                        break;
+                    }
+                } else {
+                    invokeMethod = m;
+                }
+                invoker = exporter.getInvoker();
             }
         }
-        return null;
+        return invokeMethod;
     }
 
     private static boolean isMatch(Class<?>[] types, List<Object> args) {


### PR DESCRIPTION
修复：
接口的参数sendSmsMessage(GenericRequestDto reqDto);
public class GenericRequestDto extends HashMap<String, Object>
通过telnet测试时，报找不到对应的方法。
"No such method " + sendSmsMessage + " in service " + service