### PR TITLE
url合并时移除provider的monitor参数

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 1999-2012 Alibaba Group.
+Copyright 1999-2017 Alibaba Group.
  
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/ClusterUtils.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/ClusterUtils.java
@@ -57,6 +57,10 @@ public class ClusterUtils {
 
             map.remove(Constants.ALIVE_KEY);
             map.remove(Constants.DEFAULT_KEY_PREFIX + Constants.ALIVE_KEY);
+
+            //是否开启MonitorFilter不使用提供者的
+            map.remove(Constants.MONITOR_KEY);
+            map.remove(Constants.DEFAULT_KEY_PREFIX + Constants.MONITOR_KEY);
         }
 
         if (localMap != null && localMap.size() > 0) {


### PR DESCRIPTION
消费者订阅做url合并时移除provider url上monitor参数

在实际使用中配置了provider的monitor参数，通过MonitorFilter采集性能数据并上报。
测试发现consumer层同样上报了数据，发现provider url在被订阅合并url时保留了monitor参数。