### PR TITLE
支持启动命令行配置注册ip和port

### DIFF
--- a/dubbo-admin/pom.xml
+++ b/dubbo-admin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-admin</artifactId>
     <packaging>war</packaging>

--- a/dubbo-cluster/pom.xml
+++ b/dubbo-cluster/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-cluster</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-common/pom.xml
+++ b/dubbo-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-common</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/ConfigUtils.java
@@ -186,6 +186,10 @@ public class ConfigUtils {
         return replaceProperty(properties.getProperty(key, defaultValue), (Map) properties);
     }
 
+    public static String getSystemProperty(String key) {
+        return System.getProperty(key);
+    }
+
     public static Properties loadProperties(String fileName) {
         return loadProperties(fileName, false, false);
     }

--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-config</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-config-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-config/dubbo-config-spring/pom.xml
+++ b/dubbo-config/dubbo-config-spring/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-config</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-config-spring</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-config/pom.xml
+++ b/dubbo-config/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-config</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-container/dubbo-container-api/pom.xml
+++ b/dubbo-container/dubbo-container-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-container-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/dubbo-container-jetty/pom.xml
+++ b/dubbo-container/dubbo-container-jetty/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-container-jetty</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/dubbo-container-log4j/pom.xml
+++ b/dubbo-container/dubbo-container-log4j/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-container-log4j</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/dubbo-container-logback/pom.xml
+++ b/dubbo-container/dubbo-container-logback/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-container-logback</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/dubbo-container-spring/pom.xml
+++ b/dubbo-container/dubbo-container-spring/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-container-spring</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/pom.xml
+++ b/dubbo-container/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-container</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-demo/dubbo-demo-api/pom.xml
+++ b/dubbo-demo/dubbo-demo-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-demo</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-demo-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-demo/dubbo-demo-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-consumer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-demo</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-demo-consumer</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-demo/dubbo-demo-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-provider/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-demo</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-demo-provider</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-demo/pom.xml
+++ b/dubbo-demo/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-demo</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-filter/dubbo-filter-cache/pom.xml
+++ b/dubbo-filter/dubbo-filter-cache/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-filter</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-filter-cache</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-filter/dubbo-filter-validation/pom.xml
+++ b/dubbo-filter/dubbo-filter-validation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-filter</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-filter-validation</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-filter/pom.xml
+++ b/dubbo-filter/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-filter</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-maven/pom.xml
+++ b/dubbo-maven/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>com.alibaba</groupId>
     <artifactId>dubbo</artifactId>
-    <version>2.5.6</version>
+    <version>2.5.7.docker-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Dubbo</name>
     <description>Dubbo is a distributed service framework enpowers applications with service import/export capability

--- a/dubbo-monitor/dubbo-monitor-api/pom.xml
+++ b/dubbo-monitor/dubbo-monitor-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-monitor</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-monitor-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-monitor/dubbo-monitor-default/pom.xml
+++ b/dubbo-monitor/dubbo-monitor-default/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-monitor</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-monitor-default</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-monitor/pom.xml
+++ b/dubbo-monitor/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-monitor</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-registry/dubbo-registry-api/pom.xml
+++ b/dubbo-registry/dubbo-registry-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-registry-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/com/alibaba/dubbo/registry/support/AbstractRegistry.java
@@ -83,7 +83,7 @@ public abstract class AbstractRegistry implements Registry {
         setUrl(url);
         // 启动文件保存定时器
         syncSaveFile = url.getParameter(Constants.REGISTRY_FILESAVE_SYNC_KEY, false);
-        String filename = url.getParameter(Constants.FILE_KEY, System.getProperty("user.home") + "/.dubbo/dubbo-registry-" + url.getHost() + ".cache");
+        String filename = url.getParameter(Constants.FILE_KEY, System.getProperty("user.home") + "/.dubbo/dubbo-registry-" + url.getParameter(Constants.APPLICATION_KEY) + "-" + url.getAddress() + ".cache");
         File file = null;
         if (ConfigUtils.isNotEmpty(filename)) {
             file = new File(filename);
@@ -149,28 +149,8 @@ public abstract class AbstractRegistry implements Registry {
         if (file == null) {
             return;
         }
-        Properties newProperties = new Properties();
-        // 保存之前先读取一遍，防止多个注册中心之间冲突
-        InputStream in = null;
-        try {
-            if (file.exists()) {
-                in = new FileInputStream(file);
-                newProperties.load(in);
-            }
-        } catch (Throwable e) {
-            logger.warn("Failed to load registry store file, cause: " + e.getMessage(), e);
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    logger.warn(e.getMessage(), e);
-                }
-            }
-        }
         // 保存
         try {
-            newProperties.putAll(properties);
             File lockfile = new File(file.getAbsolutePath() + ".lock");
             if (!lockfile.exists()) {
                 lockfile.createNewFile();
@@ -190,7 +170,7 @@ public abstract class AbstractRegistry implements Registry {
                         }
                         FileOutputStream outputFile = new FileOutputStream(file);
                         try {
-                            newProperties.store(outputFile, "Dubbo Registry Cache");
+                            properties.store(outputFile, "Dubbo Registry Cache");
                         } finally {
                             outputFile.close();
                         }

--- a/dubbo-registry/dubbo-registry-default/pom.xml
+++ b/dubbo-registry/dubbo-registry-default/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-registry-default</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/dubbo-registry-multicast/pom.xml
+++ b/dubbo-registry/dubbo-registry-multicast/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-registry-multicast</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/dubbo-registry-redis/pom.xml
+++ b/dubbo-registry/dubbo-registry-redis/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-registry-redis</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/dubbo-registry-zookeeper/pom.xml
+++ b/dubbo-registry/dubbo-registry-zookeeper/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-registry-zookeeper</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/pom.xml
+++ b/dubbo-registry/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-registry</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-remoting/dubbo-remoting-api/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-remoting-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-grizzly/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-grizzly/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-remoting-grizzly</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-http/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-http/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-remoting-http</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-mina/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-mina/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-remoting-mina</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-netty/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-remoting-netty</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-netty4/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty4/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>dubbo-remoting</artifactId>
         <groupId>com.alibaba</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dubbo-remoting/dubbo-remoting-p2p/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-p2p/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-remoting-p2p</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-remoting-zookeeper</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/test/java/com/alibaba/dubbo/remoting/zookeeper/curator/CuratorZookeeperClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/test/java/com/alibaba/dubbo/remoting/zookeeper/curator/CuratorZookeeperClientTest.java
@@ -1,0 +1,34 @@
+package com.alibaba.dubbo.remoting.zookeeper.curator;
+
+import com.alibaba.dubbo.common.URL;
+
+import org.junit.Test;
+
+/**
+ * @author ken.lj
+ * @date 2017/10/16
+ */
+public class CuratorZookeeperClientTest {
+
+    @Test
+    public void testCreate() {
+        CuratorZookeeperClient curatorClient = new CuratorZookeeperClient(URL.valueOf("zookeeper://127.0.0.1:2181/com.alibaba.dubbo.registry.RegistryService"));
+        String path = "/dubbo/com.alibaba.dubbo.demo.DemoService/providers";
+        curatorClient.create(path, false);
+
+        // 重复create 100次，耗时
+        long startTime = System.nanoTime();
+        for (int i = 0; i < 100; i++) {
+            curatorClient.create(path, true);
+        }
+        System.out.println("create cost: " + (System.nanoTime() - startTime) / 1000 / 1000);
+
+        // 判断100次，耗时
+        startTime = System.nanoTime();
+        for (int i = 0; i < 100; i++) {
+//            curatorClient.(path, true);
+            ;
+        }
+        System.out.println("judge cost: " + (System.nanoTime() - startTime) / 1000 / 1000);
+    }
+}

--- a/dubbo-remoting/pom.xml
+++ b/dubbo-remoting/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-remoting</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-rpc/dubbo-rpc-api/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-default/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-default/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-default</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-hessian/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-hessian/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-hessian</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-http/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-http/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-http</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-injvm/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-injvm/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-injvm</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-memcached/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-memcached/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-memcached</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-redis/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-redis/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-redis</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-rmi/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-rmi/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-rmi</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-thrift/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-thrift/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-thrift</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-webservice/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-webservice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc-webservice</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/pom.xml
+++ b/dubbo-rpc/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-rpc</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-simple/dubbo-monitor-simple/pom.xml
+++ b/dubbo-simple/dubbo-monitor-simple/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-simple</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-monitor-simple</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-simple/dubbo-registry-simple/pom.xml
+++ b/dubbo-simple/dubbo-registry-simple/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-simple</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-registry-simple</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-simple/pom.xml
+++ b/dubbo-simple/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-simple</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-test/dubbo-test-benchmark/pom.xml
+++ b/dubbo-test/dubbo-test-benchmark/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-test-benchmark</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-test/dubbo-test-compatibility/pom.xml
+++ b/dubbo-test/dubbo-test-compatibility/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-test-compatibility</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-test/dubbo-test-examples/pom.xml
+++ b/dubbo-test/dubbo-test-examples/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-test-examples</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-test/dubbo-test-integration/pom.xml
+++ b/dubbo-test/dubbo-test-integration/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-test-integration</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-test/pom.xml
+++ b/dubbo-test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo-test</artifactId>
     <packaging>pom</packaging>

--- a/dubbo/pom.xml
+++ b/dubbo/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>dubbo</artifactId>
     <packaging>jar</packaging>

--- a/hessian-lite/pom.xml
+++ b/hessian-lite/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7.docker-SNAPSHOT</version>
     </parent>
     <artifactId>hessian-lite</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alibaba</groupId>
     <artifactId>dubbo-parent</artifactId>
-    <version>2.5.6</version>
+    <version>2.5.7.docker-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <description>The parent project of dubbo</description>
@@ -366,6 +366,20 @@
             <artifactId>jmockit</artifactId>
         </dependency>
     </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>releases</id>
+            <name>releases</name>
+            <url>http://repo.alibaba-inc.com/nexus/content/repositories/releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>snapshots</id>
+            <name>snapshots</name>
+            <url>http://repo.alibaba-inc.com/nexus/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
如docker bridage网络环境下，需要指定注册宿主机ip到注册中心，通过docker端口映射实现服务调用