### PR TITLE
NPE bug fixed.

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/listener/ListenerInvokerWrapper.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/listener/ListenerInvokerWrapper.java
@@ -76,7 +76,7 @@ public class ListenerInvokerWrapper<T> implements Invoker<T> {
 
     @Override
     public String toString() {
-        return getInterface() + " -> " + getUrl() == null ? " " : getUrl().toString();
+        return getInterface() + " -> " + (getUrl() == null ? " " : getUrl().toString());
     }
 
     public void destroy() {


### PR DESCRIPTION
The operator '+' has a higher operation priority than '?:'. A NPE will be thrown if getUrl() returns null, which is not expected.