### PR TITLE
Redis注册中心destroy方法不会被执行问题

### DIFF
--- a/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
@@ -18,16 +18,16 @@ package com.alibaba.dubbo.registry.redis;
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.registry.Registry;
 import com.alibaba.dubbo.registry.RegistryFactory;
+import com.alibaba.dubbo.registry.support.AbstractRegistryFactory;
 
 /**
  * RedisRegistryFactory
  *
  * @author william.liangf
  */
-public class RedisRegistryFactory implements RegistryFactory {
+public class RedisRegistryFactory extends AbstractRegistryFactory {
 
-    public Registry getRegistry(URL url) {
+    public Registry createRegistry(URL url) {
         return new RedisRegistry(url);
     }
-
 }


### PR DESCRIPTION
ProtocolConfig.destroyAll(); 注册中心实例的destroy方法永远不会被执行的问题修复。 #44 