### PR TITLE
Fix a wrong judgment

### DIFF
--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/filter/CacheFilter.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/filter/CacheFilter.java
@@ -21,12 +21,7 @@ import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.extension.Activate;
 import com.alibaba.dubbo.common.utils.ConfigUtils;
 import com.alibaba.dubbo.common.utils.StringUtils;
-import com.alibaba.dubbo.rpc.Filter;
-import com.alibaba.dubbo.rpc.Invocation;
-import com.alibaba.dubbo.rpc.Invoker;
-import com.alibaba.dubbo.rpc.Result;
-import com.alibaba.dubbo.rpc.RpcException;
-import com.alibaba.dubbo.rpc.RpcResult;
+import com.alibaba.dubbo.rpc.*;
 
 /**
  * CacheFilter
@@ -42,14 +37,15 @@ public class CacheFilter implements Filter {
         this.cacheFactory = cacheFactory;
     }
 
+    @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
-        if (cacheFactory != null && ConfigUtils.isNotEmpty(invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.CACHE_KEY))) {
+        if (null != cacheFactory && ConfigUtils.isNotEmpty(invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.CACHE_KEY))) {
             Cache cache = cacheFactory.getCache(invoker.getUrl().addParameter(Constants.METHOD_KEY, invocation.getMethodName()));
-            if (cache != null) {
+            if (null != cache) {
                 String key = StringUtils.toArgumentString(invocation.getArguments());
-                if (cache != null && key != null) {
+                if (StringUtils.isNotEmpty(key)) {
                     Object value = cache.get(key);
-                    if (value != null) {
+                    if (null != value) {
                         return new RpcResult(value);
                     }
                     Result result = invoker.invoke(invocation);

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/AbstractCacheFactory.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/AbstractCacheFactory.java
@@ -31,10 +31,11 @@ public abstract class AbstractCacheFactory implements CacheFactory {
 
     private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<String, Cache>();
 
+    @Override
     public Cache getCache(URL url) {
         String key = url.toFullString();
         Cache cache = caches.get(key);
-        if (cache == null) {
+        if (null == cache) {
             caches.put(key, createCache(url));
             cache = caches.get(key);
         }

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/jcache/JCache.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/jcache/JCache.java
@@ -66,10 +66,12 @@ public class JCache implements com.alibaba.dubbo.cache.Cache {
         this.store = cache;
     }
 
+    @Override
     public void put(Object key, Object value) {
         store.put(key, value);
     }
 
+    @Override
     public Object get(Object key) {
         return store.get(key);
     }

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/jcache/JCacheFactory.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/jcache/JCacheFactory.java
@@ -26,6 +26,7 @@ import com.alibaba.dubbo.common.URL;
  */
 public class JCacheFactory extends AbstractCacheFactory {
 
+    @Override
     protected Cache createCache(URL url) {
         return new JCache(url);
     }

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/lru/LruCache.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/lru/LruCache.java
@@ -35,10 +35,12 @@ public class LruCache implements Cache {
         this.store = new LRUCache<Object, Object>(max);
     }
 
+    @Override
     public void put(Object key, Object value) {
         store.put(key, value);
     }
 
+    @Override
     public Object get(Object key) {
         return store.get(key);
     }

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/lru/LruCacheFactory.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/lru/LruCacheFactory.java
@@ -26,6 +26,7 @@ import com.alibaba.dubbo.common.URL;
  */
 public class LruCacheFactory extends AbstractCacheFactory {
 
+    @Override
     protected Cache createCache(URL url) {
         return new LruCache(url);
     }

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/threadlocal/ThreadLocalCache.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/threadlocal/ThreadLocalCache.java
@@ -30,6 +30,7 @@ public class ThreadLocalCache implements Cache {
 
     private final ThreadLocal<Map<Object, Object>> store;
 
+    // TODO This url is not used
     public ThreadLocalCache(URL url) {
         this.store = new ThreadLocal<Map<Object, Object>>() {
             @Override
@@ -39,10 +40,12 @@ public class ThreadLocalCache implements Cache {
         };
     }
 
+    @Override
     public void put(Object key, Object value) {
         store.get().put(key, value);
     }
 
+    @Override
     public Object get(Object key) {
         return store.get().get(key);
     }

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/threadlocal/ThreadLocalCacheFactory.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/support/threadlocal/ThreadLocalCacheFactory.java
@@ -26,6 +26,7 @@ import com.alibaba.dubbo.common.URL;
  */
 public class ThreadLocalCacheFactory extends AbstractCacheFactory {
 
+    @Override
     protected Cache createCache(URL url) {
         return new ThreadLocalCache(url);
     }


### PR DESCRIPTION
## update at CacheFilter.java
String key = StringUtils.toArgumentString(invocation.getArguments());
上述方式获取的key不为null   且cache=null的判断是冗余的             

同时  添加了dubbo-filter部分的 @Override

初看dubbo代码    如无误  望采纳
