### PR TITLE
GenericJSONConverter.json(Locale) will StackOverflowErro

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/json/GenericJSONConverter.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/json/GenericJSONConverter.java
@@ -27,6 +27,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -371,6 +372,8 @@ public class GenericJSONConverter implements JSONConverter {
                     writeValue(item, jb, writeClass);
             }
             jb.arrayEnd();
+        } else if (obj instanceof Locale) {
+            jb.valueString(obj.toString());
         } else {
             jb.objectBegin();
 

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/json/JSONTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/json/JSONTest.java
@@ -18,11 +18,13 @@ package com.alibaba.dubbo.common.json;
 import junit.framework.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -31,6 +33,12 @@ import static org.junit.Assert.assertEquals;
 public class JSONTest {
     static byte[] DEFAULT_BYTES = {3, 12, 14, 41, 12, 2, 3, 12, 4, 67, 23};
     static int DEFAULT_$$ = 152;
+
+    @Test
+    public void testLocale() throws IOException {
+        // it will throw StackOverflowError, case from
+        JSON.json(Locale.US);
+    }
 
     @Test
     public void testException() throws Exception {


### PR DESCRIPTION
老项目有时候伤不起！依赖关系有时候太多了！

fix see #906，locale的字符串反序列化为Locale对象，我想应该是ok的

比如jackson的测试代码
```
public static void main(String[] args) throws IOException {
	ObjectMapper mapper = new ObjectMapper();
	String json = mapper.writeValueAsString(Locale.US);
	System.out.println(json);
	System.out.println(mapper.readValue(json, Locale.class));
}
```