### PR TITLE
fix dubbo-admin spring3和4同时存在，使用import pom的统一管理

### DIFF
--- a/dubbo-admin/pom.xml
+++ b/dubbo-admin/pom.xml
@@ -31,52 +31,24 @@
         <eclipse.useProjectReferences>false</eclipse.useProjectReferences>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>
+    <dependencyManagement>
+   	   	<dependencies>
+   	   	   	<dependency>
+   	   	   	   	<groupId>org.springframework</groupId>
+   	   	   	   	<artifactId>spring-framework-bom</artifactId>
+   	   	   	   	<version>3.2.18.RELEASE</version>
+   	   	   	   	<scope>import</scope>
+   	   	   	   	<type>pom</type>
+   	   	   	</dependency>
+   	   	</dependencies>
+   	</dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo</artifactId>
             <version>${project.parent.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-beans</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-web</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- FIXME 临时解决spring 4和webx3.x不兼容的问题 -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>3.2.16.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>3.2.16.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>3.2.16.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>3.2.16.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-aop</artifactId>
-            <version>3.2.16.RELEASE</version>
-        </dependency>
         <dependency>
             <groupId>com.alibaba.citrus</groupId>
             <artifactId>citrus-webx-all</artifactId>


### PR DESCRIPTION
#909 

* 尝试按照spring4的配置来运行依然错误
```
    <context-param>
    	<param-name>contextClass</param-name>
    	<param-value>com.alibaba.citrus.webx.context.WebxComponentsContext</param-value>
    </context-param>
```
```
2017-11-23 11:03:32,469 ERROR [localhost-startStop-1] Context initialization failed (ContextLoader.java:350)org.springframework.web.context.ContextLoader.initWebApplicationContext
java.lang.IllegalStateException: no WebxComponentsLoader set
	at com.alibaba.citrus.util.Assert$ExceptionType$2.newInstance(Assert.java:214)
	at com.alibaba.citrus.util.Assert.assertNotNull(Assert.java:85)
	at com.alibaba.citrus.webx.context.WebxComponentsContext.getLoader(WebxComponentsContext.java:35)
	at com.alibaba.citrus.webx.context.WebxComponentsContext.postProcessBeanFactory(WebxComponentsContext.java:50)
```
* 因为时间紧，就不探索spring4的配置了
* 现在发现war中包含spring3和4的jar，所以建议优化下pom的配置。建议用import spring 3.x的pom来管理spring jar
```
    <dependencyManagement>
   	   	<dependencies>
   	   	   	<dependency>
   	   	   	   	<groupId>org.springframework</groupId>
   	   	   	   	<artifactId>spring-framework-bom</artifactId>
   	   	   	   	<version>3.2.18.RELEASE</version>
   	   	   	   	<scope>import</scope>
   	   	   	   	<type>pom</type>
   	   	   	</dependency>
   	   	</dependencies>
   	</dependencyManagement>
```