### PR TITLE
fix: RemoteInvocation supported from dubbo v2.5.7

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/StringUtils.java
@@ -227,6 +227,21 @@ public final class StringUtils {
         return sb == null ? src : sb.toString();
     }
 
+    public static List<String> splitToList(String str, char ch) {
+        List<String> result = new ArrayList<String>();
+        if (str == null) return result;
+
+        int start = 0, len = str.length();
+        for (int i = 0; i < len; i++) {
+            if (str.charAt(i) == ch) {
+                result.add(start == i ? "" : str.substring(start, i));
+                start = i + 1;
+            }
+        }
+        if (start <= len) result.add(str.substring(start));
+        return result;
+    }
+
     /**
      * split.
      *
@@ -427,5 +442,48 @@ public final class StringUtils {
             }
         }
         return buf.toString();
+    }
+
+    public static Integer fetchInt(String str, Integer defaultValue) {
+        if (str == null || str.isEmpty()) return defaultValue;
+
+        StringBuilder buf = new StringBuilder();
+        for (int i = 0, len = str.length(); i < len; i++) {
+            char ch = str.charAt(i);
+            if (ch < '0' || ch > '9') break;
+            buf.append(ch);
+        }
+        return buf.length() == 0 ? defaultValue : Integer.valueOf(buf.toString());
+    }
+
+    public static int[] toVersion(String ver) {
+        if (ver == null || ver.isEmpty()) return new int[3];
+
+        List<String> tmp = splitToList(ver, '.');
+        int[] result = new int[tmp.size()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = fetchInt(tmp.get(i), 0);
+        }
+        return result;
+    }
+
+    public static int compareVersion(String ver1, String ver2) {
+        if (ver1 == ver2) return 0;
+        if (ver1 == null) return ver2.isEmpty() ? 0 : -1;
+        if (ver2 == null) return ver1.isEmpty() ? 0 : 1;
+        if (ver1.equals(ver2)) return 0;
+        
+        int[] v1 = toVersion(ver1), v2 = toVersion(ver2);
+        if (v1.length == 0) return v2.length == 0 ? 0 : -1;
+
+        for (int i = 0, det; i < v1.length; i++) {
+            if (i >= v2.length) return 1;
+            det = v1[i] - v2[i];
+            if (det > 0) return 1;
+            if (det < 0) return -1;
+        }
+        if (v1.length < v2.length) return -1;
+        return ver1.endsWith("SNAPSHOT") ? -1 :
+            ver2.endsWith("SNAPSHOT") ? 1 : 0;
     }
 }

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/utils/StringUtilsTest.java
@@ -18,7 +18,10 @@ package com.alibaba.dubbo.common.utils;
 import junit.framework.TestCase;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class StringUtilsTest extends TestCase {
@@ -58,5 +61,46 @@ public class StringUtilsTest extends TestCase {
         assertEquals("ab-cd-ef", StringUtils.camelToSplitName("AbCdEf", "-"));
         assertEquals("ab-cd-ef", StringUtils.camelToSplitName("ab-cd-ef", "-"));
         assertEquals("abcdef", StringUtils.camelToSplitName("abcdef", "-"));
+    }
+
+    @Test
+    public void testSplitToList() {
+        assertEquals(Arrays.asList(""), StringUtils.splitToList("", '.'));
+        assertEquals(Arrays.asList("1"), StringUtils.splitToList("1", '.'));
+        assertEquals(Arrays.asList("1", ""), StringUtils.splitToList("1.", '.'));
+        assertEquals(Arrays.asList("1", "2", ""), StringUtils.splitToList("1.2.", '.'));
+        assertEquals(Arrays.asList("1", "2", "3", ""), StringUtils.splitToList("1.2.3.", '.'));
+        assertEquals(Arrays.asList("1", "2", "3", "4"), StringUtils.splitToList("1.2.3.4", '.'));
+    }
+
+    @Test
+    public void testFetchInt() {
+        assertEquals(null, StringUtils.fetchInt(null, null));
+        assertEquals(null, StringUtils.fetchInt("", null));
+        assertEquals(Integer.valueOf(1), StringUtils.fetchInt("1", null));
+        assertEquals(Integer.valueOf(1), StringUtils.fetchInt("1.", null));
+    }
+
+    @Test
+    public void testToVersion() {
+        assertArrayEquals(new int[] {0, 0, 0}, StringUtils.toVersion(""));
+        assertArrayEquals(new int[] {1}, StringUtils.toVersion("1"));
+        assertArrayEquals(new int[] {1, 0}, StringUtils.toVersion("1."));
+        assertArrayEquals(new int[] {1, 2, 0}, StringUtils.toVersion("1.2."));
+        assertArrayEquals(new int[] {1, 2, 3}, StringUtils.toVersion("1.2.3"));
+        assertArrayEquals(new int[] {1, 2, 3}, StringUtils.toVersion("1.2.3-SNAPSHOT"));
+    }
+
+    @Test
+    public void testCompareVersion() {
+        assertEquals(0, StringUtils.compareVersion("2.5.5-SNAPSHOT", "2.5.5-SNAPSHOT"));
+
+        assertEquals(-1, StringUtils.compareVersion("2.5.5-SNAPSHOT", "2.5.5"));
+        assertEquals(-1, StringUtils.compareVersion("2.5.5-SNAPSHOT", "2.5.6"));
+        assertEquals(-1, StringUtils.compareVersion("2.5.6", "2.5.7-SNAPSHOT"));
+
+        assertEquals(1, StringUtils.compareVersion("2.5.5", "2.5.5-SNAPSHOT"));
+        assertEquals(1, StringUtils.compareVersion("2.5.6", "2.5.5-SNAPSHOT"));
+        assertEquals(1, StringUtils.compareVersion("2.5.7-SNAPSHOT", "2.5.6"));
     }
 }

--- a/dubbo-rpc/dubbo-rpc-rmi/src/main/java/com/alibaba/dubbo/rpc/protocol/rmi/RmiProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/main/java/com/alibaba/dubbo/rpc/protocol/rmi/RmiProtocol.java
@@ -16,6 +16,7 @@
 package com.alibaba.dubbo.rpc.protocol.rmi;
 
 import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.utils.StringUtils;
 import com.alibaba.dubbo.rpc.RpcException;
 import com.alibaba.dubbo.rpc.protocol.AbstractProxyProtocol;
 import org.aopalliance.intercept.MethodInvocation;
@@ -71,12 +72,15 @@ public class RmiProtocol extends AbstractProxyProtocol {
     @SuppressWarnings("unchecked")
     protected <T> T doRefer(final Class<T> serviceType, final URL url) throws RpcException {
         final RmiProxyFactoryBean rmiProxyFactoryBean = new RmiProxyFactoryBean();
-        //RMI传输时使用自定义的远程执行对象，从而传递额外的参数
-        rmiProxyFactoryBean.setRemoteInvocationFactory(new RemoteInvocationFactory() {
-            public RemoteInvocation createRemoteInvocation(MethodInvocation methodInvocation) {
-                return new RmiRemoteInvocation(methodInvocation);
-            }
-        });
+        // RemoteInvocation supported from dubbo v2.5.7
+        if (StringUtils.compareVersion(url.getParameter("dubbo", ""), "2.5.7-SNAPSHOT") >= 0) {
+            //RMI传输时使用自定义的远程执行对象，从而传递额外的参数
+            rmiProxyFactoryBean.setRemoteInvocationFactory(new RemoteInvocationFactory() {
+                public RemoteInvocation createRemoteInvocation(MethodInvocation methodInvocation) {
+                    return new RmiRemoteInvocation(methodInvocation);
+                }
+            });
+        }
         rmiProxyFactoryBean.setServiceUrl(url.toIdentityString());
         rmiProxyFactoryBean.setServiceInterface(serviceType);
         rmiProxyFactoryBean.setCacheStub(true);


### PR DESCRIPTION
 #911

* 原因：公司目前环境都是dubbo2.5.4-SNAPSHOT，上2.5.7版本时因rmi协议在2.5.7引入新的RmiRemoteInvocation，所以服务提供者接受到invocation反序列化失败
```
ould not access remote service [rmi://192.168.1.10:1100/:(]; nested exception is java.rmi.ServerException: RemoteException occurred in server thread; nested exception is: 
	java.rmi.UnmarshalException: error unmarshalling arguments; nested exception is: 
	java.lang.ClassNotFoundException: com.alibaba.dubbo.rpc.protocol.rmi.RmiRemoteInvocation (no security manager: RMI class loader disabled) (org.springframework.web.context.support.XmlWebApplicationContext)(AbstractApplicationContext.java:551) 
	
	
		java.rmi.UnmarshalException: error unmarshalling arguments; nested exception is: 
	java.lang.ClassNotFoundException: com.alibaba.dubbo.rpc.protocol.rmi.RmiRemoteInvocation (no security manager: RMI class loader disabled)
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveInnerBean(BeanDefinitionValueResolver.java:313) ~[spring-beans-4.3.12.RELEASE.jar:4.3.12.RELEASE]
```