### PR TITLE
Fix demo start 127.0.0.1 command not found

### DIFF
--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
@@ -12,7 +12,7 @@ SERVER_PORT=`sed '/dubbo.protocol.port/!d;s/.*=//' conf/dubbo.properties | tr -d
 LOGS_FILE=`sed '/dubbo.log4j.file/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
 
 if [ -z "$SERVER_HOST" ]; then
-    SERVER_HOST=`127.0.0.1`
+    SERVER_HOST="127.0.0.1"
 fi
 
 if [ -z "$SERVER_NAME" ]; then


### PR DESCRIPTION
## What is the purpose of the change

修复demo provider项目运行脚本报错 127.0.0.1被当成命令执行了

## Brief changelog

fix typo

## Verifying this change

无报错
$./bin/start.sh
./bin/start.sh: line 15: 127.0.0.1: command not found
