### PR TITLE
2.5.8

### DIFF
--- a/dubbo-admin/pom.xml
+++ b/dubbo-admin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-admin</artifactId>
     <packaging>war</packaging>

--- a/dubbo-cluster/pom.xml
+++ b/dubbo-cluster/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-cluster</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-common/pom.xml
+++ b/dubbo-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-common</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-config</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-config-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-config/dubbo-config-spring/pom.xml
+++ b/dubbo-config/dubbo-config-spring/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-config</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-config-spring</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -49,7 +49,7 @@ public class ReferenceAnnotationBeanPostProcessor extends InstantiationAwareBean
     /**
      * The bean name of {@link ReferenceAnnotationBeanPostProcessor}
      */
-    public static String BEAN_NAME = "referenceAnnotationBeanPostProcessor";
+    public static final String BEAN_NAME = "referenceAnnotationBeanPostProcessor";
 
     private final Log logger = LogFactory.getLog(getClass());
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -7,23 +7,21 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyValues;
-import org.springframework.beans.factory.*;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.InjectionMetadata;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessorAdapter;
 import org.springframework.beans.factory.support.MergedBeanDefinitionPostProcessor;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.core.BridgeMethodResolver;
-import org.springframework.core.Ordered;
 import org.springframework.core.PriorityOrdered;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.beans.PropertyDescriptor;
-import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -32,7 +30,10 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static org.springframework.core.annotation.AnnotatedElementUtils.getMergedAnnotation;
+import static org.springframework.core.BridgeMethodResolver.findBridgedMethod;
+import static org.springframework.core.BridgeMethodResolver.isVisibilityBridgeMethodPair;
+import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
+import static org.springframework.core.annotation.AnnotationUtils.getAnnotation;
 
 /**
  * {@link org.springframework.beans.factory.config.BeanPostProcessor} implementation
@@ -92,7 +93,7 @@ public class ReferenceAnnotationBeanPostProcessor extends InstantiationAwareBean
             @Override
             public void doWith(Field field) throws IllegalArgumentException, IllegalAccessException {
 
-                Reference reference = findReferenceAnnotation(field);
+                Reference reference = getAnnotation(field, Reference.class);
 
                 if (reference != null) {
 
@@ -127,13 +128,13 @@ public class ReferenceAnnotationBeanPostProcessor extends InstantiationAwareBean
             @Override
             public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
 
-                Method bridgedMethod = BridgeMethodResolver.findBridgedMethod(method);
+                Method bridgedMethod = findBridgedMethod(method);
 
-                if (!BridgeMethodResolver.isVisibilityBridgeMethodPair(method, bridgedMethod)) {
+                if (!isVisibilityBridgeMethodPair(method, bridgedMethod)) {
                     return;
                 }
 
-                Reference reference = findReferenceAnnotation(bridgedMethod);
+                Reference reference = findAnnotation(bridgedMethod, Reference.class);
 
                 if (reference != null && method.equals(ClassUtils.getMostSpecificMethod(method, beanClass))) {
                     if (Modifier.isStatic(method.getModifiers())) {
@@ -198,17 +199,6 @@ public class ReferenceAnnotationBeanPostProcessor extends InstantiationAwareBean
             }
         }
         return metadata;
-    }
-
-    private Reference findReferenceAnnotation(AccessibleObject accessibleObject) {
-
-        if (accessibleObject.getAnnotations().length > 0) {
-            Reference reference = getMergedAnnotation(accessibleObject, Reference.class);
-            return reference;
-        }
-
-        return null;
-
     }
 
     @Override

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilder.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilder.java
@@ -1,6 +1,6 @@
 package com.alibaba.dubbo.config.spring.beans.factory.annotation;
 
-import com.alibaba.dubbo.config.*;
+import com.alibaba.dubbo.config.ConsumerConfig;
 import com.alibaba.dubbo.config.annotation.Reference;
 import com.alibaba.dubbo.config.spring.ReferenceBean;
 import org.springframework.context.ApplicationContext;

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboClassPathBeanDefinitionScanner.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboClassPathBeanDefinitionScanner.java
@@ -24,7 +24,11 @@ public class DubboClassPathBeanDefinitionScanner extends ClassPathBeanDefinition
     public DubboClassPathBeanDefinitionScanner(BeanDefinitionRegistry registry, boolean useDefaultFilters, Environment environment,
                                                ResourceLoader resourceLoader) {
 
-        super(registry, useDefaultFilters, environment, resourceLoader);
+        super(registry, useDefaultFilters);
+
+        setEnvironment(environment);
+
+        setResourceLoader(resourceLoader);
 
         registerAnnotationConfigProcessors(registry);
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboComponentScan.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboComponentScan.java
@@ -3,7 +3,6 @@ package com.alibaba.dubbo.config.spring.context.annotation;
 import com.alibaba.dubbo.config.annotation.Reference;
 import com.alibaba.dubbo.config.annotation.Service;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.annotation.AliasFor;
 
 import java.lang.annotation.*;
 
@@ -29,7 +28,6 @@ public @interface DubboComponentScan {
      *
      * @return the base packages to scan
      */
-    @AliasFor("basePackages")
     String[] value() default {};
 
     /**
@@ -41,7 +39,6 @@ public @interface DubboComponentScan {
      *
      * @return the base packages to scan
      */
-    @AliasFor("value")
     String[] basePackages() default {};
 
     /**

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboComponentScanRegistrar.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboComponentScanRegistrar.java
@@ -143,7 +143,10 @@ public class DubboComponentScanRegistrar implements ImportBeanDefinitionRegistra
         if (!ObjectUtils.isEmpty(beanNames)) {
 
             for (String beanName : beanNames) {
-                runtimeBeanReferences.add(new RuntimeBeanReference(beanName));
+
+                String resolvedBeanName = environment.resolvePlaceholders(beanName);
+
+                runtimeBeanReferences.add(new RuntimeBeanReference(resolvedBeanName));
             }
 
         }
@@ -151,6 +154,12 @@ public class DubboComponentScanRegistrar implements ImportBeanDefinitionRegistra
         return runtimeBeanReferences;
 
     }
+
+    private void addPropertyReference(BeanDefinitionBuilder builder, String propertyName, String beanName) {
+        String resolvedBeanName = environment.resolvePlaceholders(beanName);
+        builder.addPropertyReference(propertyName, resolvedBeanName);
+    }
+
 
     private AbstractBeanDefinition buildServiceBeanDefinition(Service service, Class<?> interfaceClass,
                                                               String annotatedServiceBeanName) {
@@ -166,7 +175,7 @@ public class DubboComponentScanRegistrar implements ImportBeanDefinitionRegistra
          */
         String providerConfigBeanName = service.provider();
         if (StringUtils.hasText(providerConfigBeanName)) {
-            builder.addPropertyReference("provider", providerConfigBeanName);
+            addPropertyReference(builder, "provider", providerConfigBeanName);
         }
 
         /**
@@ -174,7 +183,7 @@ public class DubboComponentScanRegistrar implements ImportBeanDefinitionRegistra
          */
         String monitorConfigBeanName = service.monitor();
         if (StringUtils.hasText(monitorConfigBeanName)) {
-            builder.addPropertyReference("monitor", monitorConfigBeanName);
+            addPropertyReference(builder, "monitor", monitorConfigBeanName);
         }
 
         /**
@@ -182,7 +191,7 @@ public class DubboComponentScanRegistrar implements ImportBeanDefinitionRegistra
          */
         String applicationConfigBeanName = service.application();
         if (StringUtils.hasText(applicationConfigBeanName)) {
-            builder.addPropertyReference("application", applicationConfigBeanName);
+            addPropertyReference(builder, "application", applicationConfigBeanName);
         }
 
         /**
@@ -190,7 +199,7 @@ public class DubboComponentScanRegistrar implements ImportBeanDefinitionRegistra
          */
         String moduleConfigBeanName = service.module();
         if (StringUtils.hasText(moduleConfigBeanName)) {
-            builder.addPropertyReference("application", moduleConfigBeanName);
+            addPropertyReference(builder, "module", moduleConfigBeanName);
         }
 
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboComponentScanRegistrar.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboComponentScanRegistrar.java
@@ -11,7 +11,10 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
-import org.springframework.beans.factory.support.*;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
@@ -20,7 +23,10 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
-import org.springframework.util.*;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.*;
 
@@ -269,7 +275,9 @@ public class DubboComponentScanRegistrar implements ImportBeanDefinitionRegistra
                 metadata.getAnnotationAttributes(DubboComponentScan.class.getName()));
         String[] basePackages = attributes.getStringArray("basePackages");
         Class<?>[] basePackageClasses = attributes.getClassArray("basePackageClasses");
-        Set<String> packagesToScan = new LinkedHashSet<String>();
+        String[] value = attributes.getStringArray("value");
+        // Appends value array attributes
+        Set<String> packagesToScan = new LinkedHashSet<String>(Arrays.asList(value));
         packagesToScan.addAll(Arrays.asList(basePackages));
         for (Class<?> basePackageClass : basePackageClasses) {
             packagesToScan.add(ClassUtils.getPackageName(basePackageClass));

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboConfigBindingRegistrar.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboConfigBindingRegistrar.java
@@ -1,0 +1,154 @@
+package com.alibaba.dubbo.config.spring.context.annotation;
+
+import com.alibaba.dubbo.config.AbstractConfig;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.env.*;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+
+import static com.alibaba.dubbo.config.spring.util.PropertySourcesUtils.getSubProperties;
+
+/**
+ * {@link AbstractConfig Dubbo Config} binding Bean registrar
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see EnableDubboConfigBinding
+ * @since 2.5.8
+ */
+public class DubboConfigBindingRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
+
+    private ConfigurableEnvironment environment;
+
+    @Override
+    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+
+        AnnotationAttributes attributes = AnnotationAttributes.fromMap(
+                importingClassMetadata.getAnnotationAttributes(EnableDubboConfigBinding.class.getName()));
+
+        registerBeanDefinitions(attributes, registry);
+
+    }
+
+    protected void registerBeanDefinitions(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
+
+        String prefix = environment.resolvePlaceholders(attributes.getString("prefix"));
+
+        Class<? extends AbstractConfig> configClass = attributes.getClass("type");
+
+        boolean multiple = attributes.getBoolean("multiple");
+
+        registerDubboConfigBeans(prefix, configClass, multiple, registry);
+
+    }
+
+    private void registerDubboConfigBeans(String prefix,
+                                          Class<? extends AbstractConfig> configClass,
+                                          boolean multiple,
+                                          BeanDefinitionRegistry registry) {
+
+        PropertySources propertySources = environment.getPropertySources();
+
+        Map<String, String> properties = getSubProperties(propertySources, prefix);
+
+        Set<String> beanNames = multiple ? resolveMultipleBeanNames(prefix, properties) :
+                Collections.singleton(resolveSingleBeanName(configClass, properties, registry));
+
+        for (String beanName : beanNames) {
+
+            BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(configClass);
+
+            AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
+
+            beanDefinition.setPropertyValues(resolveBeanPropertyValues(beanName, multiple, properties));
+
+            registry.registerBeanDefinition(beanName, beanDefinition);
+
+        }
+
+    }
+
+    private MutablePropertyValues resolveBeanPropertyValues(String beanName, boolean multiple,
+                                                            Map<String, String> properties) {
+
+        MutablePropertyValues propertyValues = new MutablePropertyValues();
+
+        if (multiple) { // For Multiple Beans
+
+            MutablePropertySources propertySources = new MutablePropertySources();
+            propertySources.addFirst(new MapPropertySource(beanName, new TreeMap<String, Object>(properties)));
+
+            Map<String, String> subProperties = getSubProperties(propertySources, beanName);
+
+            propertyValues.addPropertyValues(subProperties);
+
+
+        } else { // For Single Bean
+
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                String propertyName = entry.getKey();
+                if (!propertyName.contains(".")) { // ignore property name with "."
+                    propertyValues.addPropertyValue(propertyName, entry.getValue());
+                }
+            }
+
+        }
+
+        return propertyValues;
+
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+
+        Assert.isInstanceOf(ConfigurableEnvironment.class, environment);
+
+        this.environment = (ConfigurableEnvironment) environment;
+
+    }
+
+    private Set<String> resolveMultipleBeanNames(String prefix, Map<String, String> properties) {
+
+        Set<String> beanNames = new LinkedHashSet<String>();
+
+        for (String propertyName : properties.keySet()) {
+
+            int index = propertyName.indexOf(".");
+
+            if (index > 0) {
+
+                String beanName = propertyName.substring(0, index);
+
+                beanNames.add(beanName);
+            }
+
+        }
+
+        return beanNames;
+
+    }
+
+    private String resolveSingleBeanName(Class<? extends AbstractConfig> configClass, Map<String, String> properties,
+                                         BeanDefinitionRegistry registry) {
+
+        String beanName = properties.get("id");
+
+        if (!StringUtils.hasText(beanName)) {
+            BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(configClass);
+            beanName = BeanDefinitionReaderUtils.generateBeanName(builder.getRawBeanDefinition(), registry);
+        }
+
+        return beanName;
+
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboConfigBindingsRegistrar.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/DubboConfigBindingsRegistrar.java
@@ -1,0 +1,52 @@
+package com.alibaba.dubbo.config.spring.context.annotation;
+
+import com.alibaba.dubbo.config.AbstractConfig;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.Assert;
+
+/**
+ * {@link AbstractConfig Dubbo Config} binding Bean registrar for {@link EnableDubboConfigBindings}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see EnableDubboConfigBindings
+ * @see DubboConfigBindingRegistrar
+ * @since 2.5.8
+ */
+public class DubboConfigBindingsRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
+
+    private ConfigurableEnvironment environment;
+
+    @Override
+    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+
+        AnnotationAttributes attributes = AnnotationAttributes.fromMap(
+                importingClassMetadata.getAnnotationAttributes(EnableDubboConfigBindings.class.getName()));
+
+        AnnotationAttributes[] annotationAttributes = attributes.getAnnotationArray("value");
+
+        DubboConfigBindingRegistrar registrar = new DubboConfigBindingRegistrar();
+        registrar.setEnvironment(environment);
+
+        for (AnnotationAttributes element : annotationAttributes) {
+
+            registrar.registerBeanDefinitions(element, registry);
+
+        }
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+
+        Assert.isInstanceOf(ConfigurableEnvironment.class, environment);
+
+        this.environment = (ConfigurableEnvironment) environment;
+
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/EnableApplicationConfig.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/EnableApplicationConfig.java
@@ -1,0 +1,18 @@
+package com.alibaba.dubbo.config.spring.context.annotation;
+
+import com.alibaba.dubbo.config.ApplicationConfig;
+
+import java.lang.annotation.*;
+
+/**
+ * Equals {@link EnableDubboConfigBinding} for {@link ApplicationConfig} with "dubbo.application"
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since 2.5.8
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@EnableDubboConfigBinding(prefix = "dubbo.application", type = ApplicationConfig.class)
+public @interface EnableApplicationConfig {
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/EnableDubboConfigBinding.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/EnableDubboConfigBinding.java
@@ -1,0 +1,55 @@
+package com.alibaba.dubbo.config.spring.context.annotation;
+
+import com.alibaba.dubbo.config.AbstractConfig;
+import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.ModuleConfig;
+import com.alibaba.dubbo.config.RegistryConfig;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.PropertySources;
+
+import java.lang.annotation.*;
+
+/**
+ * Enables Spring's annotation-driven {@link AbstractConfig Dubbo Config} from {@link PropertySources properties}.
+ * <p>
+ * Default , {@link #prefix()} associates with a prefix of {@link PropertySources properties}, e,g. "dubbo.application."
+ * or "dubbo.application"
+ * <pre class="code">
+ * <p>
+ * </pre>
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see DubboConfigBindingRegistrar
+ * @see EnableDubboConfigBindings
+ * @since 2.5.8
+ */
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(DubboConfigBindingRegistrar.class)
+public @interface EnableDubboConfigBinding {
+
+    /**
+     * The name prefix of the properties that are valid to bind to {@link AbstractConfig Dubbo Config}.
+     *
+     * @return the name prefix of the properties to bind
+     */
+    String prefix();
+
+    /**
+     * @return The binding type of {@link AbstractConfig Dubbo Config}.
+     * @see AbstractConfig
+     * @see ApplicationConfig
+     * @see ModuleConfig
+     * @see RegistryConfig
+     */
+    Class<? extends AbstractConfig> type();
+
+    /**
+     * It indicates whether {@link #prefix()} binding to multiple Spring Beans.
+     *
+     * @return the default value is <code>false</code>
+     */
+    boolean multiple() default false;
+
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/EnableDubboConfigBindings.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/context/annotation/EnableDubboConfigBindings.java
@@ -1,0 +1,27 @@
+package com.alibaba.dubbo.config.spring.context.annotation;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.*;
+
+/**
+ * Multiple {@link EnableDubboConfigBinding} {@link Annotation}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since 2.5.8
+ * @see EnableDubboConfigBinding
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(DubboConfigBindingsRegistrar.class)
+public @interface EnableDubboConfigBindings {
+
+    /**
+     * The value of {@link EnableDubboConfigBindings}
+     *
+     * @return non-null
+     */
+    EnableDubboConfigBinding[] value();
+
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/util/BeanFactoryUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/util/BeanFactoryUtils.java
@@ -5,11 +5,12 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
-import static org.springframework.beans.factory.BeanFactoryUtils.beanNamesForTypeIncludingAncestors;
-import static org.springframework.beans.factory.BeanFactoryUtils.beanOfTypeIncludingAncestors;
-import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncludingAncestors;
+import static org.springframework.beans.factory.BeanFactoryUtils.*;
 
 /**
  * {@link BeanFactory} Utilities class

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/util/BeanFactoryUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/util/BeanFactoryUtils.java
@@ -65,7 +65,7 @@ public class BeanFactoryUtils {
 
         for (String beanName : beanNames) {
             if (StringUtils.isContains(allBeanNames, beanName)) {
-                beans.add(beanOfTypeIncludingAncestors(beanFactory, beanType));
+                beans.add(beanFactory.getBean(beanName, beanType));
             }
         }
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/util/PropertySourcesUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/util/PropertySourcesUtils.java
@@ -1,0 +1,52 @@
+package com.alibaba.dubbo.config.spring.util;
+
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.PropertySources;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * {@link PropertySources} Utilities
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see PropertySources
+ * @since 2.5.8
+ */
+public abstract class PropertySourcesUtils {
+
+    /**
+     * Get Sub {@link Properties}
+     *
+     * @param propertySources {@link PropertySources}
+     * @param prefix          the prefix of property name
+     * @return Map<String, String>
+     * @see Properties
+     */
+    public static Map<String, String> getSubProperties(PropertySources propertySources, String prefix) {
+
+        Map<String, String> subProperties = new LinkedHashMap<String, String>();
+
+        String normalizedPrefix = prefix.endsWith(".") ? prefix : prefix + ".";
+
+        for (PropertySource<?> source : propertySources) {
+            if (source instanceof EnumerablePropertySource) {
+                for (String name : ((EnumerablePropertySource<?>) source).getPropertyNames()) {
+                    if (name.startsWith(normalizedPrefix)) {
+                        String subName = name.substring(normalizedPrefix.length());
+                        Object value = source.getProperty(name);
+                        if (value instanceof String) {
+                            subProperties.put(subName, String.valueOf(value));
+                        }
+                    }
+                }
+            }
+        }
+
+        return subProperties;
+
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/DemoServiceImpl.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/DemoServiceImpl.java
@@ -1,8 +1,10 @@
 package com.alibaba.dubbo.config.spring.context.annotation;
 
-import com.alibaba.dubbo.config.annotation.Service;
 import com.alibaba.dubbo.config.spring.api.Box;
 import com.alibaba.dubbo.config.spring.api.DemoService;
+import org.springframework.stereotype.Service;
+
+;
 
 /**
  * {@link DemoService} Service implementation
@@ -10,12 +12,13 @@ import com.alibaba.dubbo.config.spring.api.DemoService;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 2.5.7
  */
-@Service(
+@com.alibaba.dubbo.config.annotation.Service(
         version = "2.5.7",
-        application = "dubbo-annotation-provider",
-        protocol = "dubbo",
-        registry = "my-registry"
+        application = "${demo.service.application}",
+        protocol = "${demo.service.protocol}",
+        registry = "${demo.service.registry}"
 )
+@Service
 public class DemoServiceImpl implements DemoService {
 
     @Override

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/DubboComponentScanRegistrarTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/DubboComponentScanRegistrarTest.java
@@ -39,7 +39,41 @@ public class DubboComponentScanRegistrarTest {
 
         ConsumerConfiguration consumerConfiguration = consumerContext.getBean(ConsumerConfiguration.class);
 
-        value = consumerConfiguration.getDemoService().sayName("Mercy");
+        demoService = consumerConfiguration.getDemoService();
+
+        value = demoService.sayName("Mercy");
+
+        Assert.assertEquals("Hello,Mercy", value);
+
+        ConsumerConfiguration.Child child = consumerContext.getBean(ConsumerConfiguration.Child.class);
+
+        // From Child
+
+        demoService = child.getDemoServiceFromChild();
+
+        Assert.assertNotNull(demoService);
+
+        value = demoService.sayName("Mercy");
+
+        Assert.assertEquals("Hello,Mercy", value);
+
+        // From Parent
+
+        demoService = child.getDemoServiceFromParent();
+
+        Assert.assertNotNull(demoService);
+
+        value = demoService.sayName("Mercy");
+
+        Assert.assertEquals("Hello,Mercy", value);
+
+        // From Ancestor
+
+        demoService = child.getDemoServiceFromAncestor();
+
+        Assert.assertNotNull(demoService);
+
+        value = demoService.sayName("Mercy");
 
         Assert.assertEquals("Hello,Mercy", value);
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/DubboConfigBindingRegistrarTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/DubboConfigBindingRegistrarTest.java
@@ -1,0 +1,70 @@
+package com.alibaba.dubbo.config.spring.context.annotation;
+
+import com.alibaba.dubbo.config.ApplicationConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * {@link DubboConfigBindingRegistrar}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since 2.5.8
+ */
+public class DubboConfigBindingRegistrarTest {
+
+    @Test
+    public void testRegisterBeanDefinitionsForSingle() {
+
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+        context.register(TestApplicationConfig.class);
+
+        context.refresh();
+
+        ApplicationConfig applicationConfig = context.getBean("applicationBean", ApplicationConfig.class);
+
+        Assert.assertEquals("dubbo-demo-application", applicationConfig.getName());
+
+
+    }
+
+    @Test
+    public void testRegisterBeanDefinitionsForMultiple() {
+
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+        context.register(TestMultipleApplicationConfig.class);
+
+        context.refresh();
+
+        ApplicationConfig applicationConfig = context.getBean("applicationBean", ApplicationConfig.class);
+
+        Assert.assertEquals("dubbo-demo-application", applicationConfig.getName());
+
+        applicationConfig = context.getBean("applicationBean2", ApplicationConfig.class);
+
+        Assert.assertEquals("dubbo-demo-application2", applicationConfig.getName());
+
+        applicationConfig = context.getBean("applicationBean3", ApplicationConfig.class);
+
+        Assert.assertEquals("dubbo-demo-application3", applicationConfig.getName());
+
+
+    }
+
+    @EnableDubboConfigBinding(prefix = "${application.prefix}", type = ApplicationConfig.class, multiple = true)
+    @PropertySource("META-INF/config.properties")
+    private static class TestMultipleApplicationConfig {
+
+    }
+
+    @EnableDubboConfigBinding(prefix = "${application.prefix}", type = ApplicationConfig.class)
+    @PropertySource("META-INF/config.properties")
+    private static class TestApplicationConfig {
+
+    }
+
+
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/DubboConfigBindingsRegistrarTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/DubboConfigBindingsRegistrarTest.java
@@ -1,0 +1,44 @@
+package com.alibaba.dubbo.config.spring.context.annotation;
+
+import com.alibaba.dubbo.config.ApplicationConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * {@link DubboConfigBindingsRegistrar} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since DubboConfigBindingsRegistrar
+ */
+public class DubboConfigBindingsRegistrarTest {
+
+    @Test
+    public void test() {
+
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+        context.register(TestConfig.class);
+
+        context.refresh();
+
+        ApplicationConfig applicationConfig = context.getBean("applicationBean", ApplicationConfig.class);
+
+        Assert.assertEquals("dubbo-demo-application", applicationConfig.getName());
+
+        Assert.assertEquals(2, context.getBeansOfType(ApplicationConfig.class).size());
+
+    }
+
+
+    @EnableDubboConfigBindings({
+            @EnableDubboConfigBinding(prefix = "${application.prefix}", type = ApplicationConfig.class),
+            @EnableDubboConfigBinding(prefix = "dubbo.application.applicationBean", type = ApplicationConfig.class)
+    })
+    @PropertySource("META-INF/config.properties")
+    private static class TestConfig {
+
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/EnableApplicationConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/EnableApplicationConfigTest.java
@@ -1,0 +1,36 @@
+package com.alibaba.dubbo.config.spring.context.annotation;
+
+import com.alibaba.dubbo.config.ApplicationConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * {@link EnableApplicationConfig} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since 2.5.8
+ */
+public class EnableApplicationConfigTest {
+
+    @Test
+    public void test() {
+
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+        context.register(TestConfig.class);
+
+        context.refresh();
+
+        ApplicationConfig applicationConfig = context.getBean("applicationBean", ApplicationConfig.class);
+
+        Assert.assertEquals("dubbo-demo-application", applicationConfig.getName());
+    }
+
+    @EnableApplicationConfig
+    @PropertySource("META-INF/config.properties")
+    private static class TestConfig {
+
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/consumer/ConsumerConfiguration.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/consumer/ConsumerConfiguration.java
@@ -4,6 +4,7 @@ import com.alibaba.dubbo.config.annotation.Reference;
 import com.alibaba.dubbo.config.spring.api.DemoService;
 import com.alibaba.dubbo.config.spring.context.annotation.DubboComponentScan;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
@@ -28,4 +29,54 @@ public class ConsumerConfiguration {
     public void setDemoService(DemoService demoService) {
         this.demoService = demoService;
     }
+
+
+    @Bean
+    public Child c() {
+        return new Child();
+    }
+
+    public static abstract class Ancestor {
+
+        @Reference(version = "2.5.7", url = "dubbo://127.0.0.1:12345")
+        private DemoService demoServiceFromAncestor;
+
+        public DemoService getDemoServiceFromAncestor() {
+            return demoServiceFromAncestor;
+        }
+
+        public void setDemoServiceFromAncestor(DemoService demoServiceFromAncestor) {
+            this.demoServiceFromAncestor = demoServiceFromAncestor;
+        }
+    }
+
+    public static abstract class Parent extends Ancestor {
+
+        private DemoService demoServiceFromParent;
+
+        public DemoService getDemoServiceFromParent() {
+            return demoServiceFromParent;
+        }
+
+        @Reference(version = "2.5.7", url = "dubbo://127.0.0.1:12345")
+        public void setDemoServiceFromParent(DemoService demoServiceFromParent) {
+            this.demoServiceFromParent = demoServiceFromParent;
+        }
+
+    }
+
+    public static class Child extends Parent {
+
+        @Reference(version = "2.5.7", url = "dubbo://127.0.0.1:12345")
+        private DemoService demoServiceFromChild;
+
+        public DemoService getDemoServiceFromChild() {
+            return demoServiceFromChild;
+        }
+
+        public void setDemoServiceFromChild(DemoService demoServiceFromChild) {
+            this.demoServiceFromChild = demoServiceFromChild;
+        }
+    }
+
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/consumer/ConsumerConfiguration.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/consumer/ConsumerConfiguration.java
@@ -7,6 +7,7 @@ import com.alibaba.dubbo.config.spring.context.annotation.DubboComponentScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.PropertySource;
 
 /**
  * @author ken.lj
@@ -17,6 +18,7 @@ import org.springframework.context.annotation.ImportResource;
         basePackageClasses = ConsumerConfiguration.class
 )
 @ImportResource("META-INF/spring/dubbo-annotation-consumer.xml")
+@PropertySource("META-INF/default.properties")
 public class ConsumerConfiguration {
 
     @Reference(version = "2.5.7", url = "dubbo://127.0.0.1:12345")

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/provider/ProviderConfiguration.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/provider/ProviderConfiguration.java
@@ -3,6 +3,7 @@ package com.alibaba.dubbo.config.spring.context.annotation.provider;
 import com.alibaba.dubbo.config.spring.context.annotation.DubboComponentScan;
 
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.PropertySource;
 
 /**
  * @author ken.lj
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.ImportResource;
  */
 @DubboComponentScan(basePackages = "com.alibaba.dubbo.config.spring.context.annotation")
 @ImportResource("META-INF/spring/dubbo-annotation-provider.xml")
+@PropertySource("META-INF/default.properties")
 public class ProviderConfiguration {
 
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/util/BeanFactoryUtilsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/util/BeanFactoryUtilsTest.java
@@ -51,7 +51,7 @@ public class BeanFactoryUtilsTest {
     @Test
     public void testGetBeans() {
 
-        applicationContext.register(TestBean.class);
+        applicationContext.register(TestBean.class, TestBean2.class);
 
         applicationContext.refresh();
 
@@ -71,6 +71,12 @@ public class BeanFactoryUtilsTest {
         List<TestBean> testBeans = BeanFactoryUtils.getBeans(applicationContext, new String[]{"testBean"}, TestBean.class);
 
         Assert.assertTrue(testBeans.isEmpty());
+
+    }
+
+
+    @Component("testBean2")
+    private static class TestBean2 extends TestBean {
 
     }
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/util/PropertySourcesUtilsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/util/PropertySourcesUtilsTest.java
@@ -1,0 +1,57 @@
+package com.alibaba.dubbo.config.spring.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link PropertySourcesUtils} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see PropertySourcesUtils
+ * @since 2.5.8
+ */
+public class PropertySourcesUtilsTest {
+
+    @Test
+    public void testGetSubProperties() {
+
+        MutablePropertySources propertySources = new MutablePropertySources();
+
+        Map<String, Object> source = new HashMap<String, Object>();
+
+        MapPropertySource propertySource = new MapPropertySource("test", source);
+
+        propertySources.addFirst(propertySource);
+
+        Map<String, String> result = PropertySourcesUtils.getSubProperties(propertySources, "user");
+
+        Assert.assertEquals(Collections.emptyMap(), result);
+
+        source.put("user.name", "Mercy");
+        source.put("user.age", "31");
+
+        Map<String, Object> expected = new HashMap<String, Object>();
+        expected.put("name", "Mercy");
+        expected.put("age", "31");
+
+        result = PropertySourcesUtils.getSubProperties(propertySources, "user");
+
+        Assert.assertEquals(expected, result);
+
+        result = PropertySourcesUtils.getSubProperties(propertySources, "");
+
+        Assert.assertEquals(Collections.emptyMap(), result);
+
+        result = PropertySourcesUtils.getSubProperties(propertySources, "no-exists");
+
+        Assert.assertEquals(Collections.emptyMap(), result);
+
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/config.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/config.properties
@@ -1,0 +1,9 @@
+application.prefix = dubbo.application.
+# single bean definition
+dubbo.application.id = applicationBean
+dubbo.application.name = dubbo-demo-application
+
+# multiple Bean definition
+dubbo.application.applicationBean.name = dubbo-demo-application
+dubbo.application.applicationBean2.name = dubbo-demo-application2
+dubbo.application.applicationBean3.name = dubbo-demo-application3

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/default.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/default.properties
@@ -1,0 +1,4 @@
+demo.service.version = 2.5.7
+demo.service.application = dubbo-annotation-provider
+demo.service.protocol = dubbo
+demo.service.registry = my-registry

--- a/dubbo-config/pom.xml
+++ b/dubbo-config/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-config</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-container/dubbo-container-api/pom.xml
+++ b/dubbo-container/dubbo-container-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-container-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/dubbo-container-jetty/pom.xml
+++ b/dubbo-container/dubbo-container-jetty/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-container-jetty</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/dubbo-container-log4j/pom.xml
+++ b/dubbo-container/dubbo-container-log4j/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-container-log4j</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/dubbo-container-logback/pom.xml
+++ b/dubbo-container/dubbo-container-logback/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-container-logback</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/dubbo-container-spring/pom.xml
+++ b/dubbo-container/dubbo-container-spring/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-container</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-container-spring</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-container/pom.xml
+++ b/dubbo-container/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-container</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-demo/dubbo-demo-api/pom.xml
+++ b/dubbo-demo/dubbo-demo-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-demo</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-demo-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-demo/dubbo-demo-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-consumer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-demo</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-demo-consumer</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-demo/dubbo-demo-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-provider/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-demo</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-demo-provider</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-demo/pom.xml
+++ b/dubbo-demo/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-demo</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-filter/dubbo-filter-cache/pom.xml
+++ b/dubbo-filter/dubbo-filter-cache/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-filter</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-filter-cache</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-filter/dubbo-filter-validation/pom.xml
+++ b/dubbo-filter/dubbo-filter-validation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-filter</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-filter-validation</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-filter/pom.xml
+++ b/dubbo-filter/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-filter</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-maven/pom.xml
+++ b/dubbo-maven/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>com.alibaba</groupId>
     <artifactId>dubbo</artifactId>
-    <version>2.5.7</version>
+    <version>2.5.8</version>
     <packaging>jar</packaging>
     <name>Dubbo</name>
     <description>Dubbo is a distributed service framework enpowers applications with service import/export capability

--- a/dubbo-maven/pom.xml
+++ b/dubbo-maven/pom.xml
@@ -70,6 +70,12 @@
             <version>3.2.5.Final</version>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.0.35.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
             <version>1.1.7</version>

--- a/dubbo-monitor/dubbo-monitor-api/pom.xml
+++ b/dubbo-monitor/dubbo-monitor-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-monitor</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-monitor-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-monitor/dubbo-monitor-default/pom.xml
+++ b/dubbo-monitor/dubbo-monitor-default/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-monitor</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-monitor-default</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-monitor/pom.xml
+++ b/dubbo-monitor/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-monitor</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-registry/dubbo-registry-api/pom.xml
+++ b/dubbo-registry/dubbo-registry-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-registry-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/dubbo-registry-default/pom.xml
+++ b/dubbo-registry/dubbo-registry-default/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-registry-default</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/dubbo-registry-multicast/pom.xml
+++ b/dubbo-registry/dubbo-registry-multicast/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-registry-multicast</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/dubbo-registry-redis/pom.xml
+++ b/dubbo-registry/dubbo-registry-redis/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-registry-redis</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/dubbo-registry-zookeeper/pom.xml
+++ b/dubbo-registry/dubbo-registry-zookeeper/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-registry</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-registry-zookeeper</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-registry/pom.xml
+++ b/dubbo-registry/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-registry</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-remoting/dubbo-remoting-api/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-remoting-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-grizzly/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-grizzly/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-remoting-grizzly</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-http/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-http/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-remoting-http</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-mina/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-mina/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-remoting-mina</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-netty/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-remoting-netty</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-netty4/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty4/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>dubbo-remoting</artifactId>
         <groupId>com.alibaba</groupId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dubbo-remoting/dubbo-remoting-p2p/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-p2p/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-remoting-p2p</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-remoting</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-remoting-zookeeper</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-remoting/pom.xml
+++ b/dubbo-remoting/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-remoting</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-rpc/dubbo-rpc-api/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-api</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-default/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-default/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-default</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-hessian/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-hessian/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-hessian</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-http/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-http/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-http</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-injvm/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-injvm/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-injvm</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-memcached/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-memcached/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-memcached</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-redis/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-redis/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-redis</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-rmi/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-rmi/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-rmi</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-thrift/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-thrift/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-thrift</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/dubbo-rpc-webservice/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-webservice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-rpc</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc-webservice</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-rpc/pom.xml
+++ b/dubbo-rpc/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-rpc</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-simple/dubbo-monitor-simple/pom.xml
+++ b/dubbo-simple/dubbo-monitor-simple/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-simple</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-monitor-simple</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-simple/dubbo-registry-simple/pom.xml
+++ b/dubbo-simple/dubbo-registry-simple/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-simple</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-registry-simple</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-simple/pom.xml
+++ b/dubbo-simple/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-simple</artifactId>
     <packaging>pom</packaging>

--- a/dubbo-test/dubbo-test-benchmark/pom.xml
+++ b/dubbo-test/dubbo-test-benchmark/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-test-benchmark</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/pom.xml
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-test-compatibility</artifactId>
+        <groupId>com.alibaba</groupId>
+        <version>2.5.8</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-test-spring3</artifactId>
+
+
+</project>

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/pom.xml
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/pom.xml
@@ -11,5 +11,34 @@
 
     <artifactId>dubbo-test-spring3</artifactId>
 
+    <properties>
+        <spring.version>3.2.18.RELEASE</spring.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-demo-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+    </dependencies>
 
 </project>

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/DefaultDemoService.java
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/DefaultDemoService.java
@@ -1,10 +1,20 @@
 package com.alibaba.dubbo.test;
 
+import com.alibaba.dubbo.config.annotation.Service;
+import com.alibaba.dubbo.demo.DemoService;
+
 /**
- * TODO
+ * Default {@link DemoService} implementation
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
- * @since TODO
+ * @since 2.5.8
  */
-public class DefaultDemoService {
+@Service
+public class DefaultDemoService implements DemoService {
+
+    @Override
+    public String sayHello(String name) {
+        return "DefaultDemoService - sayHell() : " + name;
+    }
+
 }

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/DefaultDemoService.java
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/DefaultDemoService.java
@@ -1,0 +1,10 @@
+package com.alibaba.dubbo.test;
+
+/**
+ * TODO
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since TODO
+ */
+public class DefaultDemoService {
+}

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/Spring3CompatibilityTest.java
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/Spring3CompatibilityTest.java
@@ -1,5 +1,12 @@
 package com.alibaba.dubbo.test;
 
+import com.alibaba.dubbo.demo.DemoService;
+import com.alibaba.dubbo.test.consumer.ConsumerConfiguration;
+import com.alibaba.dubbo.test.provider.ProviderConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.util.Assert;
+
 /**
  * Dubbo compatibility test on Spring 3.2.x
  *
@@ -10,6 +17,49 @@ public class Spring3CompatibilityTest {
 
     public static void main(String[] args) {
 
+        ConfigurableApplicationContext provider = startupProvider();
+
+        ConfigurableApplicationContext consumer = startConsumer();
+
+        ConsumerConfiguration consumerConfiguration = consumer.getBean(ConsumerConfiguration.class);
+
+        DemoService demoService = consumerConfiguration.getDemoService();
+
+        String value = demoService.sayHello("Mercy");
+
+        Assert.isTrue("DefaultDemoService - sayHell() : Mercy".equals(value), "Test is failed!");
+
+        System.out.println(value);
+
+        provider.close();
+        consumer.close();
+
+    }
+
+    private static ConfigurableApplicationContext startupProvider() {
+
+        ConfigurableApplicationContext context = startupApplicationContext(ProviderConfiguration.class);
+
+        System.out.println("Startup Provider ...");
+
+        return context;
+    }
+
+    private static ConfigurableApplicationContext startConsumer() {
+
+        ConfigurableApplicationContext context = startupApplicationContext(ConsumerConfiguration.class);
+
+        System.out.println("Startup Consumer ...");
+
+        return context;
+
+    }
+
+    private static ConfigurableApplicationContext startupApplicationContext(Class<?>... annotatedClasses) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.register(annotatedClasses);
+        context.refresh();
+        return context;
     }
 
 }

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/Spring3CompatibilityTest.java
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/Spring3CompatibilityTest.java
@@ -1,10 +1,15 @@
 package com.alibaba.dubbo.test;
 
 /**
- * TODO
+ * Dubbo compatibility test on Spring 3.2.x
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
- * @since TODO
+ * @since 2.5.8
  */
 public class Spring3CompatibilityTest {
+
+    public static void main(String[] args) {
+
+    }
+
 }

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/Spring3CompatibilityTest.java
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/Spring3CompatibilityTest.java
@@ -1,0 +1,10 @@
+package com.alibaba.dubbo.test;
+
+/**
+ * TODO
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since TODO
+ */
+public class Spring3CompatibilityTest {
+}

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/consumer/ConsumerConfiguration.java
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/consumer/ConsumerConfiguration.java
@@ -1,0 +1,30 @@
+package com.alibaba.dubbo.test.consumer;
+
+import com.alibaba.dubbo.config.annotation.Reference;
+import com.alibaba.dubbo.config.spring.context.annotation.DubboComponentScan;
+import com.alibaba.dubbo.demo.DemoService;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+
+/**
+ * Consumer {@Link Configuration}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since 2.5.8
+ */
+@Configuration
+@ImportResource("META-INF/spring/dubbo-consumer.xml")
+@DubboComponentScan
+public class ConsumerConfiguration {
+
+    @Reference(version = "2.5.8", url = "dubbo://127.0.0.1:12345")
+    private DemoService demoService;
+
+    public DemoService getDemoService() {
+        return demoService;
+    }
+
+    public void setDemoService(DemoService demoService) {
+        this.demoService = demoService;
+    }
+}

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/provider/DefaultDemoService.java
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/provider/DefaultDemoService.java
@@ -1,4 +1,4 @@
-package com.alibaba.dubbo.test;
+package com.alibaba.dubbo.test.provider;
 
 import com.alibaba.dubbo.config.annotation.Service;
 import com.alibaba.dubbo.demo.DemoService;
@@ -9,7 +9,12 @@ import com.alibaba.dubbo.demo.DemoService;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 2.5.8
  */
-@Service
+@Service(
+        version = "2.5.8",
+        application = "dubbo-annotation-provider",
+        protocol = "dubbo",
+        registry = "my-registry"
+)
 public class DefaultDemoService implements DemoService {
 
     @Override

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/provider/ProviderConfiguration.java
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/java/com/alibaba/dubbo/test/provider/ProviderConfiguration.java
@@ -1,0 +1,17 @@
+package com.alibaba.dubbo.test.provider;
+
+import com.alibaba.dubbo.config.spring.context.annotation.DubboComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+
+/**
+ * Provider {@Link Configuration}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @since 2.5.8
+ */
+@Configuration
+@ImportResource("META-INF/spring/dubbo-provider.xml")
+@DubboComponentScan
+public class ProviderConfiguration {
+}

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/resources/META-INF/spring/dubbo-consumer.xml
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/resources/META-INF/spring/dubbo-consumer.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 1999-2011 Alibaba Group.
+ -
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ -
+ -      http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+-->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+
+	http://code.alibabatech.com/schema/dubbo http://code.alibabatech.com/schema/dubbo/dubbo.xsd">
+
+    <!-- 当前应用信息配置 -->
+    <dubbo:application name="dubbo-annotation-consumer"/>
+
+    <!-- 连接注册中心配置 -->
+    <dubbo:registry address="N/A"/>
+
+</beans>

--- a/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/resources/META-INF/spring/dubbo-provider.xml
+++ b/dubbo-test/dubbo-test-compatibility/dubbo-test-spring3/src/main/resources/META-INF/spring/dubbo-provider.xml
@@ -1,0 +1,31 @@
+<!--
+ - Copyright 1999-2011 Alibaba Group.
+ -
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ -
+ -      http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+-->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+    http://code.alibabatech.com/schema/dubbo http://code.alibabatech.com/schema/dubbo/dubbo.xsd
+    ">
+
+    <!-- 当前应用信息配置 -->
+    <dubbo:application name="dubbo-annotation-provider"/>
+
+    <!-- 连接注册中心配置 -->
+    <dubbo:registry id="my-registry" address="N/A"/>
+
+    <dubbo:protocol name="dubbo" port="12345"/>
+
+</beans>

--- a/dubbo-test/dubbo-test-compatibility/pom.xml
+++ b/dubbo-test/dubbo-test-compatibility/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-test-compatibility</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-test/dubbo-test-compatibility/pom.xml
+++ b/dubbo-test/dubbo-test-compatibility/pom.xml
@@ -16,23 +16,41 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <modules>
+        <module>dubbo-test-spring3</module>
+    </modules>
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
         <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-test-compatibility</artifactId>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <description>The technology compatibility kit(TCK) test module of dubbo project</description>
+
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
-    <dependencies>
-        <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>dubbo</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- Dubbo -->
+            <dependency>
+                <groupId>com.alibaba</groupId>
+                <artifactId>dubbo</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <!-- Dubbo Demo API -->
+            <dependency>
+                <groupId>com.alibaba</groupId>
+                <artifactId>dubbo-demo-api</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/dubbo-test/dubbo-test-examples/pom.xml
+++ b/dubbo-test/dubbo-test-examples/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-test-examples</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-test/dubbo-test-integration/pom.xml
+++ b/dubbo-test/dubbo-test-integration/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-test</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-test-integration</artifactId>
     <packaging>jar</packaging>

--- a/dubbo-test/pom.xml
+++ b/dubbo-test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo-test</artifactId>
     <packaging>pom</packaging>

--- a/dubbo/pom.xml
+++ b/dubbo/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>dubbo</artifactId>
     <packaging>jar</packaging>

--- a/hessian-lite/pom.xml
+++ b/hessian-lite/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba</groupId>
         <artifactId>dubbo-parent</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
     </parent>
     <artifactId>hessian-lite</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alibaba</groupId>
     <artifactId>dubbo-parent</artifactId>
-    <version>2.5.7</version>
+    <version>2.5.8</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <description>The parent project of dubbo</description>

--- a/tree.txt
+++ b/tree.txt
@@ -1,0 +1,2387 @@
+[INFO] Scanning for projects...
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:hessian-lite:jar:3.2.1-fixed-2
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-common:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-container-api:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-container-api:[unknown-version], /Users/Mercy/workspace/github/mercyblitz/dubbo/dubbo-container/dubbo-container-api/pom.xml, line 44, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-container-spring:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-container-jetty:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-container-log4j:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-container-logback:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-container:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting-api:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting-netty:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting-mina:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting-grizzly:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting-p2p:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting-http:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting-netty4:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-remoting:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-api:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-default:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-injvm:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-rmi:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-hessian:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-http:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-webservice:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-thrift:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-memcached:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc-redis:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-rpc:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-filter-cache:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-filter-validation:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-filter:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-cluster:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-registry-api:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-registry-default:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-registry-multicast:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-registry-zookeeper:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-registry-redis:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-registry:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-monitor-api:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-monitor-default:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-monitor:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-config-api:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-config-spring:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-config:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo:[unknown-version], /Users/Mercy/workspace/github/mercyblitz/dubbo/dubbo/pom.xml, line 269, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ com.alibaba:dubbo:[unknown-version], /Users/Mercy/workspace/github/mercyblitz/dubbo/dubbo/pom.xml, line 281, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-registry-simple:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-monitor-simple:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-simple:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-admin:war:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-demo-api:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-demo-provider:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-demo-consumer:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-demo:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-test-benchmark:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-test-benchmark:[unknown-version], /Users/Mercy/workspace/github/mercyblitz/dubbo/dubbo-test/dubbo-test-benchmark/pom.xml, line 60, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-test-benchmark:[unknown-version], /Users/Mercy/workspace/github/mercyblitz/dubbo/dubbo-test/dubbo-test-benchmark/pom.xml, line 40, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-test-compatibility:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-test-integration:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-test-examples:jar:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-test:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ com.alibaba:dubbo-parent:2.5.8, /Users/Mercy/workspace/github/mercyblitz/dubbo/pom.xml, line 461, column 21
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.alibaba:dubbo-parent:pom:2.5.8
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 468, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 391, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 377, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ line 478, column 21
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 461, column 21
+[WARNING] 
+[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
+[WARNING] 
+[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
+[WARNING] 
+[INFO] ------------------------------------------------------------------------
+[INFO] Reactor Build Order:
+[INFO] 
+[INFO] dubbo-parent
+[INFO] Hessian Lite(Alibaba embed version)
+[INFO] dubbo-common
+[INFO] dubbo-container
+[INFO] dubbo-container-api
+[INFO] dubbo-container-spring
+[INFO] dubbo-container-jetty
+[INFO] dubbo-container-log4j
+[INFO] dubbo-container-logback
+[INFO] dubbo-remoting
+[INFO] dubbo-remoting-api
+[INFO] dubbo-remoting-netty
+[INFO] dubbo-remoting-mina
+[INFO] dubbo-remoting-grizzly
+[INFO] dubbo-remoting-p2p
+[INFO] dubbo-remoting-http
+[INFO] dubbo-remoting-zookeeper
+[INFO] dubbo-remoting-netty4
+[INFO] dubbo-rpc
+[INFO] dubbo-rpc-api
+[INFO] dubbo-rpc-default
+[INFO] dubbo-rpc-injvm
+[INFO] dubbo-rpc-rmi
+[INFO] dubbo-rpc-hessian
+[INFO] dubbo-rpc-http
+[INFO] dubbo-rpc-webservice
+[INFO] dubbo-cluster
+[INFO] dubbo-registry
+[INFO] dubbo-registry-api
+[INFO] dubbo-monitor
+[INFO] dubbo-monitor-api
+[INFO] dubbo-filter
+[INFO] dubbo-filter-validation
+[INFO] dubbo-filter-cache
+[INFO] dubbo-registry-default
+[INFO] dubbo-monitor-default
+[INFO] dubbo-registry-multicast
+[INFO] dubbo-config
+[INFO] dubbo-config-api
+[INFO] dubbo-config-spring
+[INFO] dubbo-rpc-thrift
+[INFO] dubbo-rpc-memcached
+[INFO] dubbo-rpc-redis
+[INFO] dubbo-registry-zookeeper
+[INFO] dubbo-registry-redis
+[INFO] dubbo
+[INFO] dubbo-simple
+[INFO] dubbo-registry-simple
+[INFO] dubbo-monitor-simple
+[INFO] dubbo-admin
+[INFO] dubbo-demo
+[INFO] dubbo-demo-api
+[INFO] dubbo-demo-provider
+[INFO] dubbo-demo-consumer
+[INFO] dubbo-test
+[INFO] dubbo-test-benchmark
+[INFO] dubbo-test-compatibility
+[INFO] dubbo-test-integration
+[INFO] dubbo-test-examples
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-parent 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-parent ---
+[INFO] com.alibaba:dubbo-parent:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Hessian Lite(Alibaba embed version) 3.2.1-fixed-2
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ hessian-lite ---
+[INFO] com.alibaba:hessian-lite:jar:3.2.1-fixed-2
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-common 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-common ---
+[INFO] com.alibaba:dubbo-common:jar:2.5.8
+[INFO] +- org.slf4j:slf4j-api:jar:1.7.25:provided
+[INFO] +- commons-logging:commons-logging:jar:1.2:provided
+[INFO] +- log4j:log4j:jar:1.2.16:compile
+[INFO] +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] +- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.jvnet.sorcerer:sorcerer-javac:jar:0.8:provided
+[INFO] +- cglib:cglib-nodep:jar:2.2:test
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-container 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-container ---
+[INFO] com.alibaba:dubbo-container:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-container-api 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-container-api ---
+[INFO] com.alibaba:dubbo-container-api:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |  \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-container-spring 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-container-spring ---
+[INFO] com.alibaba:dubbo-container-spring:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-container-jetty 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-container-jetty ---
+[INFO] com.alibaba:dubbo-container-jetty:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-container-log4j 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-container-log4j ---
+[INFO] com.alibaba:dubbo-container-log4j:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-container-logback 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-container-logback ---
+[INFO] com.alibaba:dubbo-container-logback:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- ch.qos.logback:logback-classic:jar:1.2.2:provided
+[INFO] |  +- ch.qos.logback:logback-core:jar:1.2.2:provided
+[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.25:provided
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting ---
+[INFO] com.alibaba:dubbo-remoting:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting-api 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting-api ---
+[INFO] com.alibaba:dubbo-remoting-api:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting-netty 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting-netty ---
+[INFO] com.alibaba:dubbo-remoting-netty:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting-mina 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting-mina ---
+[INFO] com.alibaba:dubbo-remoting-mina:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.apache.mina:mina-core:jar:1.1.7:compile
+[INFO] +- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting-grizzly 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting-grizzly ---
+[INFO] com.alibaba:dubbo-remoting-grizzly:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.glassfish.grizzly:grizzly-core:jar:2.1.4:compile
+[INFO] |  +- org.glassfish.grizzly:grizzly-framework:jar:2.1.4:compile
+[INFO] |  |  \- org.glassfish.gmbal:gmbal-api-only:jar:3.0.0-b023:compile
+[INFO] |  |     \- org.glassfish.external:management-api:jar:3.0.0-b012:compile
+[INFO] |  +- org.glassfish.grizzly:grizzly-portunif:jar:2.1.4:compile
+[INFO] |  \- org.glassfish.grizzly:grizzly-rcm:jar:2.1.4:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting-p2p 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting-p2p ---
+[INFO] com.alibaba:dubbo-remoting-p2p:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting-http 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting-http ---
+[INFO] com.alibaba:dubbo-remoting-http:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |  \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting-zookeeper 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting-zookeeper ---
+[INFO] com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.apache.zookeeper:zookeeper:jar:3.4.9:compile
+[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
+[INFO] |  +- jline:jline:jar:0.9.94:compile
+[INFO] |  \- io.netty:netty:jar:3.10.5.Final:compile
+[INFO] +- com.101tec:zkclient:jar:0.2:compile
+[INFO] +- org.apache.curator:curator-framework:jar:2.12.0:compile
+[INFO] |  \- org.apache.curator:curator-client:jar:2.12.0:compile
+[INFO] |     \- com.google.guava:guava:jar:16.0.1:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-remoting-netty4 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-remoting-netty4 ---
+[INFO] com.alibaba:dubbo-remoting-netty4:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc ---
+[INFO] com.alibaba:dubbo-rpc:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-api 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-api ---
+[INFO] com.alibaba:dubbo-rpc-api:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-default 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-default ---
+[INFO] com.alibaba:dubbo-rpc-default:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:test
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:test
+[INFO] +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:test
+[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.25:test
+[INFO] +- org.apache.mina:mina-core:jar:1.1.7:test
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-injvm 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-injvm ---
+[INFO] com.alibaba:dubbo-rpc-injvm:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-rmi 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-rmi ---
+[INFO] com.alibaba:dubbo-rpc-rmi:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-hessian 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-hessian ---
+[INFO] com.alibaba:dubbo-rpc-hessian:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- com.caucho:hessian:jar:4.0.38:compile
+[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.3:provided
+[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.6:provided
+[INFO] |  +- commons-logging:commons-logging:jar:1.2:provided
+[INFO] |  \- commons-codec:commons-codec:jar:1.9:provided
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-http 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-http ---
+[INFO] com.alibaba:dubbo-rpc-http:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-webservice 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-webservice ---
+[INFO] com.alibaba:dubbo-rpc-webservice:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- org.apache.cxf:cxf-rt-frontend-simple:jar:3.0.14:compile
+[INFO] |  +- org.apache.cxf:cxf-core:jar:3.0.14:compile
+[INFO] |  |  +- org.codehaus.woodstox:woodstox-core-asl:jar:4.4.1:compile
+[INFO] |  |  |  \- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
+[INFO] |  |  \- org.apache.ws.xmlschema:xmlschema-core:jar:2.2.2:compile
+[INFO] |  +- org.apache.cxf:cxf-rt-bindings-soap:jar:3.0.14:compile
+[INFO] |  |  \- org.apache.cxf:cxf-rt-databinding-jaxb:jar:3.0.14:compile
+[INFO] |  |     +- com.sun.xml.bind:jaxb-impl:jar:2.1.14:compile
+[INFO] |  |     |  \- com.sun.xml.fastinfoset:FastInfoset:jar:1.2.12:compile
+[INFO] |  |     \- com.sun.xml.bind:jaxb-core:jar:2.1.14:compile
+[INFO] |  |        \- javax.xml.bind:jaxb-api:jar:2.1:compile
+[INFO] |  |           +- javax.xml.stream:stax-api:jar:1.0-2:compile
+[INFO] |  |           \- javax.activation:activation:jar:1.1:compile
+[INFO] |  \- org.apache.cxf:cxf-rt-wsdl:jar:3.0.14:compile
+[INFO] |     +- wsdl4j:wsdl4j:jar:1.6.3:compile
+[INFO] |     \- asm:asm:jar:3.3.1:compile
+[INFO] +- org.apache.cxf:cxf-rt-transports-http:jar:3.0.14:compile
+[INFO] +- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-cluster 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-cluster ---
+[INFO] com.alibaba:dubbo-cluster:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- org.apache.bsf:bsf-api:jar:3.1:provided
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-registry 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-registry ---
+[INFO] com.alibaba:dubbo-registry:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-registry-api 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-registry-api ---
+[INFO] com.alibaba:dubbo-registry-api:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-monitor 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-monitor ---
+[INFO] com.alibaba:dubbo-monitor:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-monitor-api 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-monitor-api ---
+[INFO] com.alibaba:dubbo-monitor-api:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-filter 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-filter ---
+[INFO] com.alibaba:dubbo-filter:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-filter-validation 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-filter-validation ---
+[INFO] com.alibaba:dubbo-filter-validation:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:provided
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-filter-cache 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-filter-cache ---
+[INFO] com.alibaba:dubbo-filter-cache:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- javax.cache:cache-api:jar:1.0.0:provided
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-registry-default 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-registry-default ---
+[INFO] com.alibaba:dubbo-registry-default:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |     \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |        +- log4j:log4j:jar:1.2.16:compile
+[INFO] |        +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |        +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |        \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-rpc-default:jar:2.5.8:test
+[INFO] |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-remoting-api:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:test
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:test
+[INFO] +- org.apache.bsf:bsf-api:jar:3.1:test
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-monitor-default 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-monitor-default ---
+[INFO] com.alibaba:dubbo-monitor-default:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |     \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |        +- log4j:log4j:jar:1.2.16:compile
+[INFO] |        +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |        +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |        \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-rpc-default:jar:2.5.8:test
+[INFO] |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:test
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:test
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:test
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-registry-multicast 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-registry-multicast ---
+[INFO] com.alibaba:dubbo-registry-multicast:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |     \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |        +- log4j:log4j:jar:1.2.16:compile
+[INFO] |        +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |        +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |        \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-config 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-config ---
+[INFO] com.alibaba:dubbo-config:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-config-api 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-config-api ---
+[INFO] com.alibaba:dubbo-config-api:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-default:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-monitor-default:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-rpc-default:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:test
+[INFO] |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:test
+[INFO] |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:test
+[INFO] |     +- org.springframework:spring-beans:jar:4.3.10.RELEASE:test
+[INFO] |     +- org.springframework:spring-core:jar:4.3.10.RELEASE:test
+[INFO] |     |  \- commons-logging:commons-logging:jar:1.2:test
+[INFO] |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:test
+[INFO] +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:test
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:test
+[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:test
+[INFO] +- org.hibernate:hibernate-validator:jar:5.4.1.Final:test
+[INFO] |  +- org.jboss.logging:jboss-logging:jar:3.3.0.Final:test
+[INFO] |  \- com.fasterxml:classmate:jar:1.3.1:test
+[INFO] +- org.glassfish:javax.el:jar:3.0.1-b08:test
+[INFO] +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:test
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-config-spring 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-config-spring ---
+[INFO] com.alibaba:dubbo-config-spring:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] +- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- com.alibaba:dubbo-registry-default:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-monitor-default:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-rpc-default:jar:2.5.8:test
+[INFO] |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:test
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:test
+[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:test
+[INFO] +- org.hibernate:hibernate-validator:jar:5.4.1.Final:test
+[INFO] |  +- org.jboss.logging:jboss-logging:jar:3.3.0.Final:test
+[INFO] |  \- com.fasterxml:classmate:jar:1.3.1:test
+[INFO] +- org.glassfish:javax.el:jar:3.0.1-b08:test
+[INFO] +- org.springframework:spring-test:jar:4.3.10.RELEASE:test
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-thrift 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-thrift ---
+[INFO] com.alibaba:dubbo-rpc-thrift:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- org.apache.thrift:libthrift:jar:0.8.0:compile
+[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] |  +- commons-lang:commons-lang:jar:2.5:compile
+[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.3:compile
+[INFO] |  |  +- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  |  \- commons-codec:commons-codec:jar:1.9:compile
+[INFO] |  \- org.apache.httpcomponents:httpcore:jar:4.1.3:compile
+[INFO] +- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- com.alibaba:dubbo-config-spring:jar:2.5.8:test
+[INFO] |  +- com.alibaba:dubbo-config-api:jar:2.5.8:test
+[INFO] |  |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:test
+[INFO] |  |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:test
+[INFO] |  |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:test
+[INFO] |  \- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:test
+[INFO] +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:test
+[INFO] |  \- com.alibaba:dubbo-registry-api:jar:2.5.8:test
+[INFO] |     \- com.alibaba:dubbo-cluster:jar:2.5.8:test
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-memcached 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-memcached ---
+[INFO] com.alibaba:dubbo-rpc-memcached:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.googlecode.xmemcached:xmemcached:jar:1.3.6:compile
+[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-rpc-redis 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-rpc-redis ---
+[INFO] com.alibaba:dubbo-rpc-redis:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- redis.clients:jedis:jar:2.9.0:provided
+[INFO] |  \- org.apache.commons:commons-pool2:jar:2.4.2:provided
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-registry-zookeeper 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-registry-zookeeper ---
+[INFO] com.alibaba:dubbo-registry-zookeeper:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  +- org.apache.zookeeper:zookeeper:jar:3.4.9:compile
+[INFO] |  |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] |  |  +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
+[INFO] |  |  +- jline:jline:jar:0.9.94:compile
+[INFO] |  |  \- io.netty:netty:jar:3.10.5.Final:compile
+[INFO] |  +- com.101tec:zkclient:jar:0.2:compile
+[INFO] |  \- org.apache.curator:curator-framework:jar:2.12.0:compile
+[INFO] |     \- org.apache.curator:curator-client:jar:2.12.0:compile
+[INFO] |        \- com.google.guava:guava:jar:16.0.1:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-registry-redis 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-registry-redis ---
+[INFO] com.alibaba:dubbo-registry-redis:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |     \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |        +- log4j:log4j:jar:1.2.16:compile
+[INFO] |        +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |        +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |        \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- redis.clients:jedis:jar:2.9.0:provided
+[INFO] |  \- org.apache.commons:commons-pool2:jar:2.4.2:provided
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo ---
+[INFO] com.alibaba:dubbo:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- com.alibaba:dubbo-remoting-netty4:jar:2.5.8:compile
+[INFO] |  \- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  \- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-redis:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-container-spring:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-container-jetty:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-container-log4j:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-container-logback:jar:2.5.8:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-simple 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-simple ---
+[INFO] com.alibaba:dubbo-simple:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-registry-simple 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-registry-simple ---
+[INFO] com.alibaba:dubbo-registry-simple:jar:2.5.8
+[INFO] +- com.alibaba:dubbo:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  |  \- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty4:jar:2.5.8:compile
+[INFO] |  |  \- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  |  \- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-spring:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-jetty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-log4j:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-logback:jar:2.5.8:compile
+[INFO] +- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |  \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-monitor-simple 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-monitor-simple ---
+[INFO] com.alibaba:dubbo-monitor-simple:jar:2.5.8
+[INFO] +- com.alibaba:dubbo:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty4:jar:2.5.8:compile
+[INFO] |  |  \- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |     \- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  |  \- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-spring:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-jetty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-log4j:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-logback:jar:2.5.8:compile
+[INFO] +- jfree:jfreechart:jar:1.0.13:compile
+[INFO] |  \- jfree:jcommon:jar:1.0.16:compile
+[INFO] +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] +- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- org.apache.mina:mina-core:jar:1.1.7:compile
+[INFO] +- org.glassfish.grizzly:grizzly-core:jar:2.1.4:compile
+[INFO] |  +- org.glassfish.grizzly:grizzly-framework:jar:2.1.4:compile
+[INFO] |  |  \- org.glassfish.gmbal:gmbal-api-only:jar:3.0.0-b023:compile
+[INFO] |  |     \- org.glassfish.external:management-api:jar:3.0.0-b012:compile
+[INFO] |  +- org.glassfish.grizzly:grizzly-portunif:jar:2.1.4:compile
+[INFO] |  \- org.glassfish.grizzly:grizzly-rcm:jar:2.1.4:compile
+[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.3:compile
+[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.6:compile
+[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  \- commons-codec:commons-codec:jar:1.9:compile
+[INFO] +- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.thoughtworks.xstream:xstream:jar:1.4.1:compile
+[INFO] |  +- xmlpull:xmlpull:jar:1.1.3.1:compile
+[INFO] |  \- xpp3:xpp3_min:jar:1.1.4c:compile
+[INFO] +- org.apache.bsf:bsf-api:jar:3.1:compile
+[INFO] +- org.apache.zookeeper:zookeeper:jar:3.4.9:compile
+[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
+[INFO] |  +- jline:jline:jar:0.9.94:compile
+[INFO] |  \- io.netty:netty:jar:3.10.5.Final:compile
+[INFO] +- com.101tec:zkclient:jar:0.2:compile
+[INFO] +- org.apache.curator:curator-framework:jar:2.12.0:compile
+[INFO] |  \- org.apache.curator:curator-client:jar:2.12.0:compile
+[INFO] |     \- com.google.guava:guava:jar:16.0.1:compile
+[INFO] +- com.googlecode.xmemcached:xmemcached:jar:1.3.6:compile
+[INFO] +- org.apache.cxf:cxf-rt-frontend-simple:jar:3.0.14:compile
+[INFO] |  +- org.apache.cxf:cxf-core:jar:3.0.14:compile
+[INFO] |  |  +- org.codehaus.woodstox:woodstox-core-asl:jar:4.4.1:compile
+[INFO] |  |  |  \- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
+[INFO] |  |  \- org.apache.ws.xmlschema:xmlschema-core:jar:2.2.2:compile
+[INFO] |  +- org.apache.cxf:cxf-rt-bindings-soap:jar:3.0.14:compile
+[INFO] |  |  \- org.apache.cxf:cxf-rt-databinding-jaxb:jar:3.0.14:compile
+[INFO] |  |     +- com.sun.xml.bind:jaxb-impl:jar:2.1.14:compile
+[INFO] |  |     |  \- com.sun.xml.fastinfoset:FastInfoset:jar:1.2.12:compile
+[INFO] |  |     \- com.sun.xml.bind:jaxb-core:jar:2.1.14:compile
+[INFO] |  |        \- javax.xml.bind:jaxb-api:jar:2.1:compile
+[INFO] |  |           +- javax.xml.stream:stax-api:jar:1.0-2:compile
+[INFO] |  |           \- javax.activation:activation:jar:1.1:compile
+[INFO] |  \- org.apache.cxf:cxf-rt-wsdl:jar:3.0.14:compile
+[INFO] |     +- wsdl4j:wsdl4j:jar:1.6.3:compile
+[INFO] |     \- asm:asm:jar:3.3.1:compile
+[INFO] +- org.apache.cxf:cxf-rt-transports-http:jar:3.0.14:compile
+[INFO] +- org.apache.thrift:libthrift:jar:0.8.0:compile
+[INFO] |  \- commons-lang:commons-lang:jar:2.5:compile
+[INFO] +- com.caucho:hessian:jar:4.0.38:compile
+[INFO] +- javax.servlet:servlet-api:jar:2.5:compile
+[INFO] +- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |  \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- log4j:log4j:jar:1.2.16:compile
+[INFO] +- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] +- redis.clients:jedis:jar:2.9.0:compile
+[INFO] |  \- org.apache.commons:commons-pool2:jar:2.4.2:compile
+[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:compile
+[INFO] +- org.hibernate:hibernate-validator:jar:5.4.1.Final:compile
+[INFO] |  +- org.jboss.logging:jboss-logging:jar:3.3.0.Final:compile
+[INFO] |  \- com.fasterxml:classmate:jar:1.3.1:compile
+[INFO] +- javax.cache:cache-api:jar:1.0.0:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-admin 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-admin ---
+[INFO] com.alibaba:dubbo-admin:war:2.5.8
+[INFO] +- com.alibaba:dubbo:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty4:jar:2.5.8:compile
+[INFO] |  |  \- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |     \- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-spring:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-jetty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-log4j:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-logback:jar:2.5.8:compile
+[INFO] +- org.springframework:spring-context:jar:3.2.16.RELEASE:compile
+[INFO] |  \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- org.springframework:spring-beans:jar:3.2.16.RELEASE:compile
+[INFO] +- org.springframework:spring-web:jar:3.2.16.RELEASE:compile
+[INFO] +- org.springframework:spring-core:jar:3.2.16.RELEASE:compile
+[INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] +- org.springframework:spring-aop:jar:3.2.16.RELEASE:compile
+[INFO] |  \- aopalliance:aopalliance:jar:1.0:compile
+[INFO] +- com.alibaba.citrus:citrus-webx-all:jar:3.1.6:compile
+[INFO] |  +- org.apache.commons:commons-jexl:jar:2.1.1:compile
+[INFO] |  +- cglib:cglib-nodep:jar:2.2:compile
+[INFO] |  +- dom4j:dom4j:jar:1.6.1:compile
+[INFO] |  +- ecs:ecs:jar:1.4.2:compile
+[INFO] |  +- commons-codec:commons-codec:jar:1.8:compile
+[INFO] |  +- commons-fileupload:commons-fileupload:jar:1.3.1:compile
+[INFO] |  +- commons-io:commons-io:jar:2.4:compile
+[INFO] |  +- org.codehaus.groovy:groovy-all:jar:2.1.7:runtime
+[INFO] |  +- org.springframework:spring-context-support:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-tx:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-jdbc:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-orm:jar:4.3.10.RELEASE:compile
+[INFO] |  +- org.springframework:spring-webmvc:jar:4.3.10.RELEASE:compile
+[INFO] |  \- org.slf4j:jcl-over-slf4j:jar:1.7.5:compile
+[INFO] +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] +- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- org.apache.mina:mina-core:jar:1.1.7:compile
+[INFO] +- org.glassfish.grizzly:grizzly-core:jar:2.1.4:compile
+[INFO] |  +- org.glassfish.grizzly:grizzly-framework:jar:2.1.4:compile
+[INFO] |  |  \- org.glassfish.gmbal:gmbal-api-only:jar:3.0.0-b023:compile
+[INFO] |  |     \- org.glassfish.external:management-api:jar:3.0.0-b012:compile
+[INFO] |  +- org.glassfish.grizzly:grizzly-portunif:jar:2.1.4:compile
+[INFO] |  \- org.glassfish.grizzly:grizzly-rcm:jar:2.1.4:compile
+[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.3:compile
+[INFO] |  \- org.apache.httpcomponents:httpcore:jar:4.4.6:compile
+[INFO] +- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- com.thoughtworks.xstream:xstream:jar:1.4.1:compile
+[INFO] |  +- xmlpull:xmlpull:jar:1.1.3.1:compile
+[INFO] |  \- xpp3:xpp3_min:jar:1.1.4c:compile
+[INFO] +- org.apache.bsf:bsf-api:jar:3.1:compile
+[INFO] +- org.apache.zookeeper:zookeeper:jar:3.4.9:compile
+[INFO] |  +- jline:jline:jar:0.9.94:compile
+[INFO] |  \- io.netty:netty:jar:3.10.5.Final:compile
+[INFO] +- com.101tec:zkclient:jar:0.2:compile
+[INFO] +- org.apache.curator:curator-framework:jar:2.12.0:compile
+[INFO] |  \- org.apache.curator:curator-client:jar:2.12.0:compile
+[INFO] |     \- com.google.guava:guava:jar:16.0.1:compile
+[INFO] +- com.googlecode.xmemcached:xmemcached:jar:1.3.6:compile
+[INFO] +- org.apache.thrift:libthrift:jar:0.8.0:compile
+[INFO] |  \- commons-lang:commons-lang:jar:2.5:compile
+[INFO] +- com.caucho:hessian:jar:4.0.38:compile
+[INFO] +- javax.servlet:servlet-api:jar:2.5:provided
+[INFO] +- log4j:log4j:jar:1.2.16:compile
+[INFO] +- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
+[INFO] +- redis.clients:jedis:jar:2.9.0:compile
+[INFO] |  \- org.apache.commons:commons-pool2:jar:2.4.2:compile
+[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:compile
+[INFO] +- org.hibernate:hibernate-validator:jar:5.4.1.Final:compile
+[INFO] |  +- org.jboss.logging:jboss-logging:jar:3.3.0.Final:compile
+[INFO] |  \- com.fasterxml:classmate:jar:1.3.1:compile
+[INFO] +- javax.cache:cache-api:jar:1.0.0:compile
+[INFO] +- org.apache.velocity:velocity:jar:1.7:compile
+[INFO] |  \- commons-collections:commons-collections:jar:3.2.1:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-demo 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-demo ---
+[INFO] com.alibaba:dubbo-demo:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-demo-api 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-demo-api ---
+[INFO] com.alibaba:dubbo-demo-api:jar:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-demo-provider 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-demo-provider ---
+[INFO] com.alibaba:dubbo-demo-provider:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-demo-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty4:jar:2.5.8:compile
+[INFO] |  |  \- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |     \- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  |  \- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-spring:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-jetty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-log4j:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-logback:jar:2.5.8:compile
+[INFO] +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] +- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- org.apache.zookeeper:zookeeper:jar:3.4.9:compile
+[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
+[INFO] |  +- jline:jline:jar:0.9.94:compile
+[INFO] |  \- io.netty:netty:jar:3.10.5.Final:compile
+[INFO] +- com.101tec:zkclient:jar:0.2:compile
+[INFO] +- org.apache.curator:curator-framework:jar:2.12.0:compile
+[INFO] |  \- org.apache.curator:curator-client:jar:2.12.0:compile
+[INFO] |     \- com.google.guava:guava:jar:16.0.1:compile
+[INFO] +- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- log4j:log4j:jar:1.2.16:compile
+[INFO] +- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-demo-consumer 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-demo-consumer ---
+[INFO] com.alibaba:dubbo-demo-consumer:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-demo-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty4:jar:2.5.8:compile
+[INFO] |  |  \- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |     \- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  |  \- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-spring:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-jetty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-log4j:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-logback:jar:2.5.8:compile
+[INFO] +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] +- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- org.apache.zookeeper:zookeeper:jar:3.4.9:compile
+[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
+[INFO] |  +- jline:jline:jar:0.9.94:compile
+[INFO] |  \- io.netty:netty:jar:3.10.5.Final:compile
+[INFO] +- com.101tec:zkclient:jar:0.2:compile
+[INFO] +- org.apache.curator:curator-framework:jar:2.12.0:compile
+[INFO] |  \- org.apache.curator:curator-client:jar:2.12.0:compile
+[INFO] |     \- com.google.guava:guava:jar:16.0.1:compile
+[INFO] +- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] +- log4j:log4j:jar:1.2.16:compile
+[INFO] +- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-test 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-test ---
+[INFO] com.alibaba:dubbo-test:pom:2.5.8
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-test-benchmark 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-test-benchmark ---
+[INFO] com.alibaba:dubbo-test-benchmark:jar:2.5.8
+[INFO] +- com.alibaba:dubbo:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  |  \- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty4:jar:2.5.8:compile
+[INFO] |  |  \- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  |  \- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-spring:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-jetty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-log4j:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-logback:jar:2.5.8:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-test-compatibility 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-test-compatibility ---
+[INFO] com.alibaba:dubbo-test-compatibility:jar:2.5.8
+[INFO] +- com.alibaba:dubbo:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |  |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |  |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  |  \- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-netty4:jar:2.5.8:compile
+[INFO] |  |  \- io.netty:netty-all:jar:4.0.35.Final:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |     +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |     +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |     +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |     \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  |  \- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-redis:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-spring:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-jetty:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-container-log4j:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-logback:jar:2.5.8:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-test-integration 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-test-integration ---
+[INFO] com.alibaba:dubbo-test-integration:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- org.apache.mina:mina-core:jar:1.1.7:compile
+[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  \- org.glassfish.grizzly:grizzly-core:jar:2.1.4:compile
+[INFO] |     +- org.glassfish.grizzly:grizzly-framework:jar:2.1.4:compile
+[INFO] |     |  \- org.glassfish.gmbal:gmbal-api-only:jar:3.0.0-b023:compile
+[INFO] |     |     \- org.glassfish.external:management-api:jar:3.0.0-b012:compile
+[INFO] |     +- org.glassfish.grizzly:grizzly-portunif:jar:2.1.4:compile
+[INFO] |     \- org.glassfish.grizzly:grizzly-rcm:jar:2.1.4:compile
+[INFO] +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  \- com.caucho:hessian:jar:4.0.38:compile
+[INFO] +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |     +- org.apache.zookeeper:zookeeper:jar:3.4.9:compile
+[INFO] |     |  +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
+[INFO] |     |  +- jline:jline:jar:0.9.94:compile
+[INFO] |     |  \- io.netty:netty:jar:3.10.5.Final:compile
+[INFO] |     +- com.101tec:zkclient:jar:0.2:compile
+[INFO] |     \- org.apache.curator:curator-framework:jar:2.12.0:compile
+[INFO] |        \- org.apache.curator:curator-client:jar:2.12.0:compile
+[INFO] |           \- com.google.guava:guava:jar:16.0.1:compile
+[INFO] +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:compile
+[INFO] +- org.hibernate:hibernate-validator:jar:5.4.1.Final:compile
+[INFO] |  +- org.jboss.logging:jboss-logging:jar:3.3.0.Final:compile
+[INFO] |  \- com.fasterxml:classmate:jar:1.3.1:compile
+[INFO] +- org.glassfish:javax.el:jar:3.0.1-b08:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building dubbo-test-examples 2.5.8
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ dubbo-test-examples ---
+[INFO] com.alibaba:dubbo-test-examples:jar:2.5.8
+[INFO] +- com.alibaba:dubbo-config-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-registry-api:jar:2.5.8:compile
+[INFO] |  |  \- com.alibaba:dubbo-cluster:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-monitor-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-remoting-api:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-filter-validation:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-filter-cache:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-config-spring:jar:2.5.8:compile
+[INFO] |  +- org.springframework:spring-beans:jar:4.3.10.RELEASE:compile
+[INFO] |  |  \- org.springframework:spring-core:jar:4.3.10.RELEASE:compile
+[INFO] |  |     \- commons-logging:commons-logging:jar:1.2:compile
+[INFO] |  \- org.springframework:spring-context:jar:4.3.10.RELEASE:compile
+[INFO] |     +- org.springframework:spring-aop:jar:4.3.10.RELEASE:compile
+[INFO] |     \- org.springframework:spring-expression:jar:4.3.10.RELEASE:compile
+[INFO] +- com.alibaba:dubbo-remoting-netty:jar:2.5.8:compile
+[INFO] |  \- org.jboss.netty:netty:jar:3.2.5.Final:compile
+[INFO] +- com.alibaba:dubbo-remoting-mina:jar:2.5.8:compile
+[INFO] |  +- org.apache.mina:mina-core:jar:1.1.7:compile
+[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.25:compile
+[INFO] +- com.alibaba:dubbo-remoting-grizzly:jar:2.5.8:compile
+[INFO] |  \- org.glassfish.grizzly:grizzly-core:jar:2.1.4:compile
+[INFO] |     +- org.glassfish.grizzly:grizzly-framework:jar:2.1.4:compile
+[INFO] |     |  \- org.glassfish.gmbal:gmbal-api-only:jar:3.0.0-b023:compile
+[INFO] |     |     \- org.glassfish.external:management-api:jar:3.0.0-b012:compile
+[INFO] |     +- org.glassfish.grizzly:grizzly-portunif:jar:2.1.4:compile
+[INFO] |     \- org.glassfish.grizzly:grizzly-rcm:jar:2.1.4:compile
+[INFO] +- com.alibaba:dubbo-remoting-p2p:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-remoting-http:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-common:jar:2.5.8:compile
+[INFO] |  |  +- log4j:log4j:jar:1.2.16:compile
+[INFO] |  |  +- org.javassist:javassist:jar:3.20.0-GA:compile
+[INFO] |  |  +- com.alibaba:hessian-lite:jar:3.2.1-fixed-2:compile
+[INFO] |  |  \- com.alibaba:fastjson:jar:1.2.31:compile
+[INFO] |  \- org.mortbay.jetty:jetty:jar:6.1.26:compile
+[INFO] |     +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
+[INFO] |     \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
+[INFO] +- com.alibaba:dubbo-rpc-default:jar:2.5.8:compile
+[INFO] |  +- com.alibaba:dubbo-rpc-api:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-container-api:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-injvm:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-rmi:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-rpc-hessian:jar:2.5.8:compile
+[INFO] |  \- com.caucho:hessian:jar:4.0.38:compile
+[INFO] +- com.alibaba:dubbo-rpc-http:jar:2.5.8:compile
+[INFO] |  \- org.springframework:spring-web:jar:4.3.10.RELEASE:compile
+[INFO] +- com.alibaba:dubbo-rpc-webservice:jar:2.5.8:compile
+[INFO] |  +- org.apache.cxf:cxf-rt-frontend-simple:jar:3.0.14:compile
+[INFO] |  |  +- org.apache.cxf:cxf-core:jar:3.0.14:compile
+[INFO] |  |  |  +- org.codehaus.woodstox:woodstox-core-asl:jar:4.4.1:compile
+[INFO] |  |  |  |  \- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
+[INFO] |  |  |  \- org.apache.ws.xmlschema:xmlschema-core:jar:2.2.2:compile
+[INFO] |  |  +- org.apache.cxf:cxf-rt-bindings-soap:jar:3.0.14:compile
+[INFO] |  |  |  \- org.apache.cxf:cxf-rt-databinding-jaxb:jar:3.0.14:compile
+[INFO] |  |  |     +- com.sun.xml.bind:jaxb-impl:jar:2.1.14:compile
+[INFO] |  |  |     |  \- com.sun.xml.fastinfoset:FastInfoset:jar:1.2.12:compile
+[INFO] |  |  |     \- com.sun.xml.bind:jaxb-core:jar:2.1.14:compile
+[INFO] |  |  |        \- javax.xml.bind:jaxb-api:jar:2.1:compile
+[INFO] |  |  |           +- javax.xml.stream:stax-api:jar:1.0-2:compile
+[INFO] |  |  |           \- javax.activation:activation:jar:1.1:compile
+[INFO] |  |  \- org.apache.cxf:cxf-rt-wsdl:jar:3.0.14:compile
+[INFO] |  |     +- wsdl4j:wsdl4j:jar:1.6.3:compile
+[INFO] |  |     \- asm:asm:jar:3.3.1:compile
+[INFO] |  \- org.apache.cxf:cxf-rt-transports-http:jar:3.0.14:compile
+[INFO] +- com.alibaba:dubbo-rpc-thrift:jar:2.5.8:compile
+[INFO] |  \- org.apache.thrift:libthrift:jar:0.8.0:compile
+[INFO] |     +- commons-lang:commons-lang:jar:2.5:compile
+[INFO] |     +- org.apache.httpcomponents:httpclient:jar:4.5.3:compile
+[INFO] |     |  \- commons-codec:commons-codec:jar:1.9:compile
+[INFO] |     \- org.apache.httpcomponents:httpcore:jar:4.1.3:compile
+[INFO] +- com.alibaba:dubbo-rpc-memcached:jar:2.5.8:compile
+[INFO] |  \- com.googlecode.xmemcached:xmemcached:jar:1.3.6:compile
+[INFO] +- com.alibaba:dubbo-rpc-redis:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-default:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-multicast:jar:2.5.8:compile
+[INFO] +- com.alibaba:dubbo-registry-zookeeper:jar:2.5.8:compile
+[INFO] |  \- com.alibaba:dubbo-remoting-zookeeper:jar:2.5.8:compile
+[INFO] |     +- org.apache.zookeeper:zookeeper:jar:3.4.9:compile
+[INFO] |     |  +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
+[INFO] |     |  +- jline:jline:jar:0.9.94:compile
+[INFO] |     |  \- io.netty:netty:jar:3.10.5.Final:compile
+[INFO] |     +- com.101tec:zkclient:jar:0.2:compile
+[INFO] |     \- org.apache.curator:curator-framework:jar:2.12.0:compile
+[INFO] |        \- org.apache.curator:curator-client:jar:2.12.0:compile
+[INFO] |           \- com.google.guava:guava:jar:16.0.1:compile
+[INFO] +- com.alibaba:dubbo-monitor-default:jar:2.5.8:compile
+[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:compile
+[INFO] +- org.hibernate:hibernate-validator:jar:5.4.1.Final:compile
+[INFO] |  +- org.jboss.logging:jboss-logging:jar:3.3.0.Final:compile
+[INFO] |  \- com.fasterxml:classmate:jar:1.3.1:compile
+[INFO] +- redis.clients:jedis:jar:2.9.0:compile
+[INFO] |  \- org.apache.commons:commons-pool2:jar:2.4.2:compile
+[INFO] +- org.glassfish:javax.el:jar:3.0.1-b08:compile
+[INFO] +- javax.cache:cache-api:jar:1.0.0:compile
+[INFO] +- junit:junit:jar:4.12:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.easymock:easymock:jar:3.4:test
+[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
+[INFO] \- org.jmockit:jmockit:jar:1.33:test
+[INFO] ------------------------------------------------------------------------
+[INFO] Reactor Summary:
+[INFO] 
+[INFO] dubbo-parent ....................................... SUCCESS [  0.837 s]
+[INFO] Hessian Lite(Alibaba embed version) ................ SUCCESS [  0.031 s]
+[INFO] dubbo-common ....................................... SUCCESS [  0.026 s]
+[INFO] dubbo-container .................................... SUCCESS [  0.007 s]
+[INFO] dubbo-container-api ................................ SUCCESS [  0.019 s]
+[INFO] dubbo-container-spring ............................. SUCCESS [  0.018 s]
+[INFO] dubbo-container-jetty .............................. SUCCESS [  0.009 s]
+[INFO] dubbo-container-log4j .............................. SUCCESS [  0.009 s]
+[INFO] dubbo-container-logback ............................ SUCCESS [  0.017 s]
+[INFO] dubbo-remoting ..................................... SUCCESS [  0.008 s]
+[INFO] dubbo-remoting-api ................................. SUCCESS [  0.008 s]
+[INFO] dubbo-remoting-netty ............................... SUCCESS [  0.013 s]
+[INFO] dubbo-remoting-mina ................................ SUCCESS [  0.012 s]
+[INFO] dubbo-remoting-grizzly ............................. SUCCESS [  0.023 s]
+[INFO] dubbo-remoting-p2p ................................. SUCCESS [  0.009 s]
+[INFO] dubbo-remoting-http ................................ SUCCESS [  0.025 s]
+[INFO] dubbo-remoting-zookeeper ........................... SUCCESS [  0.036 s]
+[INFO] dubbo-remoting-netty4 .............................. SUCCESS [  0.018 s]
+[INFO] dubbo-rpc .......................................... SUCCESS [  0.007 s]
+[INFO] dubbo-rpc-api ...................................... SUCCESS [  0.033 s]
+[INFO] dubbo-rpc-default .................................. SUCCESS [  0.015 s]
+[INFO] dubbo-rpc-injvm .................................... SUCCESS [  0.009 s]
+[INFO] dubbo-rpc-rmi ...................................... SUCCESS [  0.009 s]
+[INFO] dubbo-rpc-hessian .................................. SUCCESS [  0.060 s]
+[INFO] dubbo-rpc-http ..................................... SUCCESS [  0.015 s]
+[INFO] dubbo-rpc-webservice ............................... SUCCESS [  0.081 s]
+[INFO] dubbo-cluster ...................................... SUCCESS [  0.012 s]
+[INFO] dubbo-registry ..................................... SUCCESS [  0.005 s]
+[INFO] dubbo-registry-api ................................. SUCCESS [  0.008 s]
+[INFO] dubbo-monitor ...................................... SUCCESS [  0.008 s]
+[INFO] dubbo-monitor-api .................................. SUCCESS [  0.007 s]
+[INFO] dubbo-filter ....................................... SUCCESS [  0.008 s]
+[INFO] dubbo-filter-validation ............................ SUCCESS [  0.011 s]
+[INFO] dubbo-filter-cache ................................. SUCCESS [  0.009 s]
+[INFO] dubbo-registry-default ............................. SUCCESS [  0.013 s]
+[INFO] dubbo-monitor-default .............................. SUCCESS [  0.017 s]
+[INFO] dubbo-registry-multicast ........................... SUCCESS [  0.018 s]
+[INFO] dubbo-config ....................................... SUCCESS [  0.017 s]
+[INFO] dubbo-config-api ................................... SUCCESS [  0.045 s]
+[INFO] dubbo-config-spring ................................ SUCCESS [  0.019 s]
+[INFO] dubbo-rpc-thrift ................................... SUCCESS [  0.029 s]
+[INFO] dubbo-rpc-memcached ................................ SUCCESS [  0.012 s]
+[INFO] dubbo-rpc-redis .................................... SUCCESS [  0.015 s]
+[INFO] dubbo-registry-zookeeper ........................... SUCCESS [  0.017 s]
+[INFO] dubbo-registry-redis ............................... SUCCESS [  0.020 s]
+[INFO] dubbo .............................................. SUCCESS [  0.078 s]
+[INFO] dubbo-simple ....................................... SUCCESS [  0.005 s]
+[INFO] dubbo-registry-simple .............................. SUCCESS [  0.025 s]
+[INFO] dubbo-monitor-simple ............................... SUCCESS [  0.054 s]
+[INFO] dubbo-admin ........................................ SUCCESS [  0.107 s]
+[INFO] dubbo-demo ......................................... SUCCESS [  0.004 s]
+[INFO] dubbo-demo-api ..................................... SUCCESS [  0.004 s]
+[INFO] dubbo-demo-provider ................................ SUCCESS [  0.027 s]
+[INFO] dubbo-demo-consumer ................................ SUCCESS [  0.026 s]
+[INFO] dubbo-test ......................................... SUCCESS [  0.005 s]
+[INFO] dubbo-test-benchmark ............................... SUCCESS [  0.027 s]
+[INFO] dubbo-test-compatibility ........................... SUCCESS [  0.020 s]
+[INFO] dubbo-test-integration ............................. SUCCESS [  0.026 s]
+[INFO] dubbo-test-examples ................................ SUCCESS [  0.032 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 2.963 s
+[INFO] Finished at: 2017-11-07T14:47:43+08:00
+[INFO] Final Memory: 29M/98M
+[INFO] ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

### Add Annotation `@EnableDubboConfigBinding` for properties to bind Dubbo Config

### Add Annotation `@EnableDubboConfigBindings` for multiple annotated purposes

see [issue](https://github.com/mercyblitz/dubbo/issues/12)

### Add `@DubboComponentScan` compatibility for Spring 3.2.x

see [issue](https://github.com/alibaba/dubbo/issues/813)

### Add part-support of Property placeholders for `@DubboComponentScan`

For example : 
```java
@com.alibaba.dubbo.config.annotation.Service(
        version = "2.5.7",
        application = "${demo.service.application}",
        protocol = "${demo.service.protocol}",
        registry = "${demo.service.registry}"
)
```

## Verifying this change

### Run `DubboConfigBindingRegistrarTest` for test cases
### Run `DubboConfigBindingsRegistrarTest` for test cases

