### PR TITLE
fix class DubboMonitorFactory  name spelling for #190 

### DIFF
--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/com/alibaba/dubbo/monitor/support/AbstractMonitorFactory.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/com/alibaba/dubbo/monitor/support/AbstractMonitorFactory.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * AbstractMonitorFactroy. (SPI, Singleton, ThreadSafe)
+ * AbstractMonitorFactory. (SPI, Singleton, ThreadSafe)
  *
  * @author william.liangf
  */

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/com/alibaba/dubbo/monitor/dubbo/DubboMonitorFactory.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/com/alibaba/dubbo/monitor/dubbo/DubboMonitorFactory.java
@@ -25,11 +25,11 @@ import com.alibaba.dubbo.rpc.Protocol;
 import com.alibaba.dubbo.rpc.ProxyFactory;
 
 /**
- * DefaultMonitorFactroy
+ * DefaultMonitorFactory
  *
  * @author william.liangf
  */
-public class DubboMonitorFactroy extends AbstractMonitorFactory {
+public class DubboMonitorFactory extends AbstractMonitorFactory {
 
     private Protocol protocol;
 

--- a/dubbo-monitor/dubbo-monitor-default/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.monitor.MonitorFactory
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.monitor.MonitorFactory
@@ -1,1 +1,1 @@
-dubbo=com.alibaba.dubbo.monitor.dubbo.DubboMonitorFactroy
+dubbo=com.alibaba.dubbo.monitor.dubbo.DubboMonitorFactory


### PR DESCRIPTION
## What is the purpose of the change

https://github.com/alibaba/dubbo/issues/190 fix class DubboMonitorFactory name spelling

## Brief changelog
fix class name
dubbo/dubbo-monitor/dubbo-monitor-default/src/main/java/com/alibaba/dubbo/monitor/dubbo/DubboMonitorFactory.java