### PR TITLE
bugfix: throw a NPE in deserialization process when one property of java.sql.Time type happens to be null

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/JavaDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/JavaDeserializer.java
@@ -621,7 +621,7 @@ public class JavaDeserializer extends AbstractMapDeserializer {
 
             try {
                 java.util.Date date = (java.util.Date) in.readObject();
-                value = new java.sql.Time(date.getTime());
+                if (date != null) value = new java.sql.Time(date.getTime());
 
                 _field.set(obj, value);
             } catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

RPC调用反序列化过程中，如果对象的成员变量的类型为java.sql.Time，且其值为NULL，则抛出NPE。

## Brief changelog
添加了必要的非空检查
