### PR TITLE
[Dubbo-#1085]Change the DEFAULT_RETRIES from 2 to 0.

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
@@ -133,7 +133,7 @@ public class Constants {
 
     public static final int DEFAULT_CONNECT_TIMEOUT = 3000;
 
-    public static final int DEFAULT_RETRIES = 2;
+    public static final int DEFAULT_RETRIES = 0;
 
     // default buffer size is 8k.
     public static final int DEFAULT_BUFFER_SIZE = 8 * 1024;


### PR DESCRIPTION
## What is the purpose of the change

Fix the #1085 and #1142 

## Brief changelog

Change the DEFAULT_RETRIES from 2 to 0.

## Verifying this change

## Reason
When  retreis property isn't setup in both Reference and Service, the URL will have no retreis property.
So below code been executed, the Constans.DEFAULT_RETRIES will be used.

``` 
// file: FailoverClusterInvoker.java  line: 56
int len = getUrl().getMethodParameter(invocation.getMethodName(), Constants.RETRIES_KEY, Constants.DEFAULT_RETRIES) + 1;
```
So if we setup the retreis property of Refercence or Service, even set it's equal 0, the URL will have retries property, the Constans.DEFAULT_RETRIES will not be used.
