### PR TITLE
ThreadPool新增扩展点：增强型线程池

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedTaskQueue.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedTaskQueue.java
@@ -1,0 +1,73 @@
+package com.alibaba.dubbo.common.threadpool.support.enhanced;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * enhanced task queue
+ */
+public class EnhancedTaskQueue<R extends Runnable> extends LinkedBlockingQueue<Runnable> {
+
+    private static final long serialVersionUID = -2635853580887179627L;
+
+    private EnhancedThreadPoolExecutor executor;
+
+    public EnhancedTaskQueue(int capacity) {
+        super(capacity);
+    }
+
+    public void setExecutor(EnhancedThreadPoolExecutor exec) {
+        executor = exec;
+    }
+
+    @Override
+    public boolean offer(Runnable runnable) {
+        if (executor == null) {
+            throw new RejectedExecutionException("enhanced queue does not have executor !");
+        }
+        int currentPoolThreadSize = executor.getPoolSize();
+        //have free worker. put task into queue to let the worker deal with task.
+        if (executor.getSubmittedTaskCount() < currentPoolThreadSize) {
+            return super.offer(runnable);
+        }
+
+        // return false to let executor create new worker.
+        if (currentPoolThreadSize < executor.getMaximumPoolSize()) {
+            return false;
+        }
+
+        //currentPoolThreadSize >= max
+        return super.offer(runnable);
+
+//        int currentPoolThreadSize = executor.getPoolSize();
+//        //如果线程池里的线程数量已经到达最大,将任务添加到队列中
+//        if (currentPoolThreadSize == executor.getMaximumPoolSize()) {
+//            return super.offer(runnable);
+//        }
+//        //说明有空闲的线程,这个时候无需创建core线程之外的线程,而是把任务直接丢到队列里即可
+//        if (executor.getSubmittedTaskCount() < currentPoolThreadSize) {
+//            return super.offer(runnable);
+//        }
+//
+//        //如果线程池里的线程数量还没有到达最大,直接创建线程,而不是把任务丢到队列里面
+//        if (currentPoolThreadSize < executor.getMaximumPoolSize()) {
+//            return false;
+//        }
+//
+//        return super.offer(runnable);
+    }
+
+    /**
+     * retry offer task
+     *
+     * @param o task
+     * @return offer success or not
+     * @throws RejectedExecutionException if executor is terminated.
+     */
+    public boolean retryOffer(Runnable o) {
+        if (executor.isShutdown()) {
+            throw new RejectedExecutionException("Executor is shutdown !");
+        }
+        return super.offer(o);
+    }
+}

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedTaskQueue.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedTaskQueue.java
@@ -38,23 +38,6 @@ public class EnhancedTaskQueue<R extends Runnable> extends LinkedBlockingQueue<R
 
         //currentPoolThreadSize >= max
         return super.offer(runnable);
-
-//        int currentPoolThreadSize = executor.getPoolSize();
-//        //如果线程池里的线程数量已经到达最大,将任务添加到队列中
-//        if (currentPoolThreadSize == executor.getMaximumPoolSize()) {
-//            return super.offer(runnable);
-//        }
-//        //说明有空闲的线程,这个时候无需创建core线程之外的线程,而是把任务直接丢到队列里即可
-//        if (executor.getSubmittedTaskCount() < currentPoolThreadSize) {
-//            return super.offer(runnable);
-//        }
-//
-//        //如果线程池里的线程数量还没有到达最大,直接创建线程,而不是把任务丢到队列里面
-//        if (currentPoolThreadSize < executor.getMaximumPoolSize()) {
-//            return false;
-//        }
-//
-//        return super.offer(runnable);
     }
 
     /**

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedThreadPool.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedThreadPool.java
@@ -1,0 +1,32 @@
+package com.alibaba.dubbo.common.threadpool.support.enhanced;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.threadpool.ThreadPool;
+import com.alibaba.dubbo.common.threadpool.support.AbortPolicyWithReport;
+import com.alibaba.dubbo.common.utils.NamedThreadFactory;
+
+import java.util.concurrent.*;
+
+/**
+ * enhanced thread pool.
+ * When the core threads are all in busy , create new thread instead of putting task into blocking queue .
+ */
+public class EnhancedThreadPool implements ThreadPool {
+
+    @Override
+    public Executor getExecutor(URL url) {
+        String name = url.getParameter(Constants.THREAD_NAME_KEY, Constants.DEFAULT_THREAD_NAME);
+        int cores = url.getParameter(Constants.CORE_THREADS_KEY, Constants.DEFAULT_CORE_THREADS);
+        int threads = url.getParameter(Constants.THREADS_KEY, Integer.MAX_VALUE);
+        int queues = url.getParameter(Constants.QUEUES_KEY, Constants.DEFAULT_QUEUES);
+        int alive = url.getParameter(Constants.ALIVE_KEY, Constants.DEFAULT_ALIVE);
+
+        //init queue and enhanced executor
+        EnhancedTaskQueue<Runnable> enhancedTaskQueue = new EnhancedTaskQueue<Runnable>(queues <= 0 ? 1 : queues);
+        EnhancedThreadPoolExecutor executor = new EnhancedThreadPoolExecutor(cores, threads, alive, TimeUnit.MILLISECONDS, enhancedTaskQueue,
+                new NamedThreadFactory(name, true), new AbortPolicyWithReport(name, url));
+        enhancedTaskQueue.setExecutor(executor);
+        return executor;
+    }
+}

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedThreadPoolExecutor.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedThreadPoolExecutor.java
@@ -1,0 +1,45 @@
+package com.alibaba.dubbo.common.threadpool.support.enhanced;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Enhanced thread pool
+ */
+public class EnhancedThreadPoolExecutor extends ThreadPoolExecutor {
+
+    //task count
+    private final AtomicInteger submittedTaskCount = new AtomicInteger(0);
+
+    public EnhancedThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, EnhancedTaskQueue<Runnable> workQueue, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+    }
+
+    /**
+     * @return current tasks which are executed
+     */
+    public int getSubmittedTaskCount() {
+        return submittedTaskCount.get();
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        submittedTaskCount.decrementAndGet();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        //do not increment in method beforeExecute!
+        submittedTaskCount.incrementAndGet();
+        try {
+            super.execute(command);
+        } catch (RejectedExecutionException rx) {
+            //retry to offer the task into queue .
+            final EnhancedTaskQueue queue = (EnhancedTaskQueue<Runnable>) super.getQueue();
+            if (!queue.retryOffer(command)) {
+                submittedTaskCount.decrementAndGet();
+                throw new RejectedExecutionException();
+            }
+        }
+    }
+}

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.common.threadpool.ThreadPool
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.common.threadpool.ThreadPool
@@ -1,3 +1,4 @@
 fixed=com.alibaba.dubbo.common.threadpool.support.fixed.FixedThreadPool
 cached=com.alibaba.dubbo.common.threadpool.support.cached.CachedThreadPool
 limited=com.alibaba.dubbo.common.threadpool.support.limited.LimitedThreadPool
+enhanced=com.alibaba.dubbo.common.threadpool.support.enhanced.EnhancedThreadPool

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedThreadPoolTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/threadpool/support/enhanced/EnhancedThreadPoolTest.java
@@ -1,0 +1,68 @@
+package com.alibaba.dubbo.common.threadpool.support.enhanced;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.threadpool.support.AbortPolicyWithReport;
+import com.alibaba.dubbo.common.utils.NamedThreadFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class EnhancedThreadPoolTest {
+
+    /**
+     * it print like this:
+     * thread number in current pool：1,  task number in task queue：0 executor size: 1
+     * thread number in current pool：2,  task number in task queue：0 executor size: 2
+     * thread number in current pool：3,  task number in task queue：0 executor size: 3
+     * thread number in current pool：4,  task number in task queue：0 executor size: 4
+     * thread number in current pool：5,  task number in task queue：0 executor size: 5
+     * thread number in current pool：6,  task number in task queue：0 executor size: 6
+     * thread number in current pool：7,  task number in task queue：0 executor size: 7
+     * thread number in current pool：8,  task number in task queue：0 executor size: 8
+     * thread number in current pool：9,  task number in task queue：0 executor size: 9
+     * thread number in current pool：10,  task number in task queue：0 executor size: 10
+     * thread number in current pool：10,  task number in task queue：4 executor size: 10
+     * thread number in current pool：10,  task number in task queue：3 executor size: 10
+     * thread number in current pool：10,  task number in task queue：2 executor size: 10
+     * thread number in current pool：10,  task number in task queue：1 executor size: 10
+     * thread number in current pool：10,  task number in task queue：0 executor size: 10
+     *
+     * we can see , when the core threads are in busy , the thread pool create thread (but thread nums always less than max) instead of put task into queue.
+     */
+    @Test
+    public void testEnhancedThreadPool() throws Exception {
+        String name = "enhanced-tf";
+        int queues = 5;
+        int cores = 5;
+        int threads = 10;
+        //alive 1 second
+        long alive = 1000;
+        URL url = new URL("dubbo", "localhost", 8080);
+
+        //init queue and enhanced executor
+        EnhancedTaskQueue<Runnable> enhancedTaskQueue = new EnhancedTaskQueue<Runnable>(queues);
+        final EnhancedThreadPoolExecutor executor = new EnhancedThreadPoolExecutor(cores, threads, alive, TimeUnit.MILLISECONDS, enhancedTaskQueue,
+                new NamedThreadFactory(name, true), new AbortPolicyWithReport(name, url));
+        enhancedTaskQueue.setExecutor(executor);
+
+        for (int i = 0; i < 15; i++) {
+            Thread.sleep(50);
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    System.out.println("thread number in current pool：" + executor.getPoolSize() + ",  task number in task queue：" + executor.getQueue().size() + " executor size: " + executor.getPoolSize());
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+        }
+        Thread.sleep(5000);
+        //cores theads are all alive
+        Assert.assertTrue("more than cores threads alive!", executor.getPoolSize() == cores);
+    }
+
+}

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/SerializerFactory.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/SerializerFactory.java
@@ -79,6 +79,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -226,9 +227,9 @@ public class SerializerFactory extends AbstractSerializerFactory {
     private ClassLoader _loader;
     private Deserializer _hashMapDeserializer;
     private Deserializer _arrayListDeserializer;
-    private HashMap _cachedSerializerMap;
-    private HashMap _cachedDeserializerMap;
-    private HashMap _cachedTypeDeserializerMap;
+    private ConcurrentHashMap _cachedSerializerMap;
+    private ConcurrentHashMap _cachedDeserializerMap;
+    private ConcurrentHashMap _cachedTypeDeserializerMap;
     private boolean _isAllowNonSerializable;
 
     public SerializerFactory() {
@@ -293,21 +294,21 @@ public class SerializerFactory extends AbstractSerializerFactory {
      * @param cl the class of the object that needs to be serialized.
      * @return a serializer object for the serialization.
      */
+    @Override
     public Serializer getSerializer(Class cl)
             throws HessianProtocolException {
         Serializer serializer;
 
         serializer = (Serializer) _staticSerializerMap.get(cl);
-        if (serializer != null)
+        if (serializer != null) {
             return serializer;
+        }
 
         if (_cachedSerializerMap != null) {
-            synchronized (_cachedSerializerMap) {
-                serializer = (Serializer) _cachedSerializerMap.get(cl);
-            }
-
-            if (serializer != null)
+            serializer = (Serializer) _cachedSerializerMap.get(cl);
+            if (serializer != null) {
                 return serializer;
+            }
         }
 
         for (int i = 0;
@@ -346,39 +347,33 @@ public class SerializerFactory extends AbstractSerializerFactory {
             }
 
             serializer = _collectionSerializer;
-        } else if (cl.isArray())
+        } else if (cl.isArray()) {
             serializer = new ArraySerializer();
-
-        else if (Throwable.class.isAssignableFrom(cl))
+        } else if (Throwable.class.isAssignableFrom(cl)) {
             serializer = new ThrowableSerializer(cl, getClassLoader());
-
-        else if (InputStream.class.isAssignableFrom(cl))
+        } else if (InputStream.class.isAssignableFrom(cl)) {
             serializer = new InputStreamSerializer();
-
-        else if (Iterator.class.isAssignableFrom(cl))
+        } else if (Iterator.class.isAssignableFrom(cl)) {
             serializer = IteratorSerializer.create();
-
-        else if (Enumeration.class.isAssignableFrom(cl))
+        } else if (Enumeration.class.isAssignableFrom(cl)) {
             serializer = EnumerationSerializer.create();
-
-        else if (Calendar.class.isAssignableFrom(cl))
+        } else if (Calendar.class.isAssignableFrom(cl)) {
             serializer = CalendarSerializer.create();
-
-        else if (Locale.class.isAssignableFrom(cl))
+        } else if (Locale.class.isAssignableFrom(cl)) {
             serializer = LocaleSerializer.create();
-
-        else if (Enum.class.isAssignableFrom(cl))
+        } else if (Enum.class.isAssignableFrom(cl)) {
             serializer = new EnumSerializer(cl);
-
-        if (serializer == null)
-            serializer = getDefaultSerializer(cl);
-
-        if (_cachedSerializerMap == null)
-            _cachedSerializerMap = new HashMap(8);
-
-        synchronized (_cachedSerializerMap) {
-            _cachedSerializerMap.put(cl, serializer);
         }
+
+        if (serializer == null) {
+            serializer = getDefaultSerializer(cl);
+        }
+
+        if (_cachedSerializerMap == null) {
+            _cachedSerializerMap = new ConcurrentHashMap(8);
+        }
+
+        _cachedSerializerMap.put(cl, serializer);
 
         return serializer;
     }
@@ -418,10 +413,7 @@ public class SerializerFactory extends AbstractSerializerFactory {
             return deserializer;
 
         if (_cachedDeserializerMap != null) {
-            synchronized (_cachedDeserializerMap) {
-                deserializer = (Deserializer) _cachedDeserializerMap.get(cl);
-            }
-
+            deserializer = (Deserializer) _cachedDeserializerMap.get(cl);
             if (deserializer != null)
                 return deserializer;
         }
@@ -462,11 +454,9 @@ public class SerializerFactory extends AbstractSerializerFactory {
             deserializer = getDefaultDeserializer(cl);
 
         if (_cachedDeserializerMap == null)
-            _cachedDeserializerMap = new HashMap(8);
+            _cachedDeserializerMap = new ConcurrentHashMap(8);
 
-        synchronized (_cachedDeserializerMap) {
-            _cachedDeserializerMap.put(cl, deserializer);
-        }
+        _cachedDeserializerMap.put(cl, deserializer);
 
         return deserializer;
     }
@@ -624,9 +614,7 @@ public class SerializerFactory extends AbstractSerializerFactory {
         Deserializer deserializer;
 
         if (_cachedTypeDeserializerMap != null) {
-            synchronized (_cachedTypeDeserializerMap) {
-                deserializer = (Deserializer) _cachedTypeDeserializerMap.get(type);
-            }
+            deserializer = (Deserializer) _cachedTypeDeserializerMap.get(type);
 
             if (deserializer != null)
                 return deserializer;
@@ -657,11 +645,9 @@ public class SerializerFactory extends AbstractSerializerFactory {
 
         if (deserializer != null) {
             if (_cachedTypeDeserializerMap == null)
-                _cachedTypeDeserializerMap = new HashMap(8);
+                _cachedTypeDeserializerMap = new ConcurrentHashMap(8);
 
-            synchronized (_cachedTypeDeserializerMap) {
-                _cachedTypeDeserializerMap.put(type, deserializer);
-            }
+            _cachedTypeDeserializerMap.put(type, deserializer);
         }
 
         return deserializer;

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/SerializerFactoryTest.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/SerializerFactoryTest.java
@@ -1,0 +1,86 @@
+package com.alibaba.com.caucho.hessian.io;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+public class SerializerFactoryTest {
+
+    private static final int THREADS = 10;
+
+    @Test
+    public void getSerializer() throws Exception {
+        final SerializerFactory serializerFactory = new SerializerFactory();
+        final Class<TestClass> klass = TestClass.class;
+
+        Serializer s1 = serializerFactory.getSerializer(klass);
+        Serializer s2 = serializerFactory.getSerializer(klass);
+
+        Assert.assertTrue("several Serializer!", s1 == s2);
+    }
+
+    @Test
+    public void getSerializerDuplicateThread() throws Exception {
+        final SerializerFactory serializerFactory = new SerializerFactory();
+        final Class<TestClass> klass = TestClass.class;
+        final CountDownLatch countDownLatch = new CountDownLatch(THREADS);
+
+        //init into cached map
+        final Serializer s = serializerFactory.getSerializer(klass);
+
+        //get from duplicate thread
+        for (int i = 0; i < THREADS; i++) {
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Assert.assertTrue("serveral Serializer!", s == serializerFactory.getSerializer(klass));
+                    } catch (HessianProtocolException e) {
+                        e.printStackTrace();
+                    }
+                    countDownLatch.countDown();
+                }
+            }).start();
+        }
+        countDownLatch.await();
+    }
+
+    @Test
+    public void getDeserializer() throws Exception {
+        final SerializerFactory serializerFactory = new SerializerFactory();
+        final Class<TestClass> klass = TestClass.class;
+
+        Deserializer d1 = serializerFactory.getDeserializer(klass);
+        Deserializer d2 = serializerFactory.getDeserializer(klass);
+
+        Assert.assertTrue("several Deserializer!", d1 == d2);
+    }
+
+    @Test
+    public void getDeserializerDuplicateThread() throws Exception {
+        final SerializerFactory serializerFactory = new SerializerFactory();
+        final Class<TestClass> klass = TestClass.class;
+        final CountDownLatch countDownLatch = new CountDownLatch(THREADS);
+
+        //init into cached map
+        final Deserializer s = serializerFactory.getDeserializer(klass);
+
+        //get from duplicate thread
+        for (int i = 0; i < THREADS; i++) {
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Assert.assertTrue("serveral Deserializer!", s == serializerFactory.getDeserializer(klass));
+                    } catch (HessianProtocolException e) {
+                        e.printStackTrace();
+                    }
+                    countDownLatch.countDown();
+                }
+            }).start();
+        }
+        countDownLatch.await();
+    }
+
+}

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/SerializerFactoryTest.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/SerializerFactoryTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 
 public class SerializerFactoryTest {
 
-    private static final int THREADS = 10;
+    private static final int THREADS = 50;
 
     @Test
     public void getSerializer() throws Exception {

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/TestClass.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/TestClass.java
@@ -1,0 +1,6 @@
+package com.alibaba.com.caucho.hessian.io;
+
+import java.io.Serializable;
+
+public class TestClass implements Serializable {
+}


### PR DESCRIPTION
当cores线程数全都使用的情况下，默认线程池会把任务放入到队列中。队列满则再创建线程（总数不会超过Max线程数）
增强线程池：比fixed更好的应对请求量大的情况
特性：cores线程全部使用的情况下，优先创建线程（总数不会超过max），当max个线程全都在忙的情况下，才将任务放入队列。请求量下降时，线程池会自动维持cores个线程，多余的线程退出。