### PR TITLE
修改telnet协议默认编码

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/com/alibaba/dubbo/remoting/telnet/codec/TelnetCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/com/alibaba/dubbo/remoting/telnet/codec/TelnetCodec.java
@@ -77,7 +77,7 @@ public class TelnetCodec extends TransportCodec {
             }
         }
         try {
-            return Charset.forName("GBK");
+            return Charset.forName("UTF-8");
         } catch (Throwable t) {
             logger.warn(t.getMessage(), t);
         }


### PR DESCRIPTION
默认编码应该和dubbo:protocol中对默认编码的设定保持一致，以消除不必要的认识误区，给开发增加调试成本。