### PR TITLE
Error in getting local address for Dubbo Log

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/NetUtils.java
@@ -183,7 +183,7 @@ public class NetUtils {
     }
 
     public static String getLogHost() {
-        InetAddress address = LOCAL_ADDRESS;
+        InetAddress address = getLocalAddress();
         return address == null ? LOCALHOST : address.getHostAddress();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

fix dubbo default Log bug, default wrong local ip output is 127.0.0.1 

## Brief changelog

fix address printed error in log

