### PR TITLE
Fix hessian2 serialized short, byte is converted to int bug

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractDeserializer.java
@@ -77,6 +77,9 @@ abstract public class AbstractDeserializer implements Deserializer {
 
     @Override
     public Object readList(AbstractHessianInput in, int length, Class<?> expectType) throws IOException {
+        if(expectType == null) {
+            return readList(in, length);
+        }
         throw new UnsupportedOperationException(String.valueOf(this));
     }
 
@@ -87,6 +90,9 @@ abstract public class AbstractDeserializer implements Deserializer {
 
     @Override
     public Object readLengthList(AbstractHessianInput in, int length, Class<?> expectType) throws IOException {
+        if(expectType == null){
+            return readLengthList(in , length);
+        }
         throw new UnsupportedOperationException(String.valueOf(this));
     }
 
@@ -104,6 +110,9 @@ abstract public class AbstractDeserializer implements Deserializer {
 
     @Override
     public Object readMap(AbstractHessianInput in, Class<?> expectKeyType, Class<?> expectValueType) throws IOException {
+        if(expectKeyType  == null && expectValueType == null){
+            return readMap(in);
+        }
         throw new UnsupportedOperationException(String.valueOf(this));
     }
 

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractDeserializer.java
@@ -75,8 +75,18 @@ abstract public class AbstractDeserializer implements Deserializer {
         throw new UnsupportedOperationException(String.valueOf(this));
     }
 
+    @Override
+    public Object readList(AbstractHessianInput in, int length, Class<?> expectType) throws IOException {
+        throw new UnsupportedOperationException(String.valueOf(this));
+    }
+
     public Object readLengthList(AbstractHessianInput in, int length)
             throws IOException {
+        throw new UnsupportedOperationException(String.valueOf(this));
+    }
+
+    @Override
+    public Object readLengthList(AbstractHessianInput in, int length, Class<?> expectType) throws IOException {
         throw new UnsupportedOperationException(String.valueOf(this));
     }
 
@@ -90,6 +100,11 @@ abstract public class AbstractDeserializer implements Deserializer {
             throw error(className + ": unexpected object " + obj.getClass().getName() + " (" + obj + ")");
         else
             throw error(className + ": unexpected null value");
+    }
+
+    @Override
+    public Object readMap(AbstractHessianInput in, Class<?> expectKeyType, Class<?> expectValueType) throws IOException {
+        throw new UnsupportedOperationException(String.valueOf(this));
     }
 
     public Object readObject(AbstractHessianInput in, String[] fieldNames)
@@ -106,5 +121,16 @@ abstract public class AbstractDeserializer implements Deserializer {
             return "end of file";
         else
             return "0x" + Integer.toHexString(ch & 0xff);
+    }
+
+    protected SerializerFactory findSerializerFactory(AbstractHessianInput in) {
+        SerializerFactory serializerFactory = null;
+        if(in instanceof Hessian2Input) {
+            serializerFactory = ((Hessian2Input) in).findSerializerFactory();
+        }
+        else if(in instanceof HessianInput) {
+            serializerFactory = ((HessianInput) in).getSerializerFactory();
+        }
+        return serializerFactory == null? new SerializerFactory(): serializerFactory;
     }
 }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractHessianInput.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractHessianInput.java
@@ -51,6 +51,7 @@ package com.alibaba.com.caucho.hessian.io;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.util.List;
 
 /**
  * Abstract base class for Hessian requests.  Hessian users should only
@@ -336,9 +337,31 @@ abstract public class AbstractHessianInput {
 
     /**
      * Reads an arbitrary object from the input stream.
+     *
+     * @param expectedClass the expected class if the protocol doesn't supply it.
+     * @param expectedTypes the runtime type hints, eg: expectedClass equals Map, expectedTypes can
+     * equals String.class, Short.class
+     */
+    public Object readObject(Class expectedClass, Class<?>... expectedTypes)
+        throws IOException{
+        throw new UnsupportedOperationException(String.valueOf(this));
+    }
+
+    /**
+     * Reads an arbitrary object from the input stream.
      */
     abstract public Object readObject()
             throws IOException;
+
+    /**
+     * Reads an arbitrary object from the input stream.
+     * @param expectedTypes the runtime type hints, eg: expectedTypes can
+     * equals String.class, Short.class for HashMap
+     */
+    public Object readObject(List<Class<?>> expectedTypes)
+        throws IOException{
+        throw new UnsupportedOperationException(String.valueOf(this));
+    }
 
     /**
      * Reads a remote object reference to the stream.  The type is the

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/CollectionDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/CollectionDeserializer.java
@@ -73,12 +73,24 @@ public class CollectionDeserializer extends AbstractListDeserializer {
 
     public Object readList(AbstractHessianInput in, int length)
             throws IOException {
+        return readList(in, length, null);
+    }
+
+    @Override
+    public Object readList(AbstractHessianInput in, int length, Class<?> expectType) throws IOException {
         Collection list = createList();
 
         in.addRef(list);
 
+        Deserializer deserializer = null;
+
+        SerializerFactory factory = findSerializerFactory(in);
+        if(expectType != null){
+            deserializer = factory.getDeserializer(expectType.getName());
+        }
+
         while (!in.isEnd())
-            list.add(in.readObject());
+            list.add(deserializer != null ? deserializer.readObject(in) : in.readObject());
 
         in.readEnd();
 
@@ -87,12 +99,24 @@ public class CollectionDeserializer extends AbstractListDeserializer {
 
     public Object readLengthList(AbstractHessianInput in, int length)
             throws IOException {
+        return readList(in, length, null);
+    }
+
+    @Override
+    public Object readLengthList(AbstractHessianInput in, int length, Class<?> expectType) throws IOException {
         Collection list = createList();
 
         in.addRef(list);
 
+        Deserializer deserializer = null;
+
+        SerializerFactory factory = findSerializerFactory(in);
+        if(expectType != null){
+            deserializer = factory.getDeserializer(expectType.getName());
+        }
+
         for (; length > 0; length--)
-            list.add(in.readObject());
+            list.add(deserializer != null ? deserializer.readObject(in) : in.readObject());
 
         return list;
     }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Deserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Deserializer.java
@@ -52,6 +52,8 @@ import java.io.IOException;
 
 /**
  * Deserializing an object.
+ *
+ * @author jason.shang@hotmail.com
  */
 public interface Deserializer {
     public Class getType();
@@ -62,11 +64,48 @@ public interface Deserializer {
     public Object readList(AbstractHessianInput in, int length)
             throws IOException;
 
+    /**
+     *
+     * deserialize list object from expect type.
+     *
+     * @param in
+     * @param length
+     * @param expectType
+     * @return
+     * @throws IOException
+     */
+    public Object readList(AbstractHessianInput in, int length, Class<?> expectType)
+        throws IOException;
+
     public Object readLengthList(AbstractHessianInput in, int length)
             throws IOException;
 
+    /**
+     *
+     * deserialize list object from expect type.
+     *
+     * @param in
+     * @param length
+     * @param expectType
+     * @return
+     * @throws IOException
+     */
+    public Object readLengthList(AbstractHessianInput in, int length, Class<?> expectType)
+        throws IOException;
+
     public Object readMap(AbstractHessianInput in)
             throws IOException;
+
+    /**
+     *  deserialize map object from expect key and value type.
+     * @param in
+     * @param expectKeyType
+     * @param expectValueType
+     * @return
+     * @throws IOException
+     */
+    public Object readMap(AbstractHessianInput in, Class<?> expectKeyType, Class<?> expectValueType )
+        throws IOException;
 
     public Object readObject(AbstractHessianInput in, String[] fieldNames)
             throws IOException;

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/SerializerFactory.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/SerializerFactory.java
@@ -501,16 +501,24 @@ public class SerializerFactory extends AbstractSerializerFactory {
      */
     public Object readMap(AbstractHessianInput in, String type)
             throws HessianProtocolException, IOException {
+        return readMap(in, type, null, null);
+    }
+
+    /**
+     * Reads the object as a map.
+     */
+    public Object readMap(AbstractHessianInput in, String type, Class<?> expectKeyType, Class<?> expectValueType)
+        throws HessianProtocolException, IOException {
         Deserializer deserializer = getDeserializer(type);
 
         if (deserializer != null)
             return deserializer.readMap(in);
         else if (_hashMapDeserializer != null)
-            return _hashMapDeserializer.readMap(in);
+            return _hashMapDeserializer.readMap(in, expectKeyType, expectValueType);
         else {
             _hashMapDeserializer = new MapDeserializer(HashMap.class);
 
-            return _hashMapDeserializer.readMap(in);
+            return _hashMapDeserializer.readMap(in, expectKeyType, expectValueType);
         }
     }
 

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2StringShortTest.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2StringShortTest.java
@@ -1,0 +1,157 @@
+package com.alibaba.com.caucho.hessian.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+/**
+ * @author jason.shang@hotmail.com
+ */
+public class Hessian2StringShortTest {
+
+    @Test
+    public void serialize_string_short_map_then_deserialize() throws Exception {
+
+        Hessian2StringShortType stringShort = new Hessian2StringShortType();
+        Map<String, Short> stringShortMap = new HashMap<String, Short>();
+        stringShortMap.put("first", (short)0);
+        stringShortMap.put("last", (short)60);
+        stringShort.stringShortMap = stringShortMap;
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        Hessian2Output out = new Hessian2Output(bout);
+
+        out.writeObject(stringShort);
+        out.flush();
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
+        Hessian2Input input = new Hessian2Input(bin);
+
+        Hessian2StringShortType deserialize = (Hessian2StringShortType) input.readObject();
+        assertTrue(deserialize.stringShortMap != null);
+        assertTrue(deserialize.stringShortMap.size() == 2);
+        assertTrue(deserialize.stringShortMap.get("last") instanceof Short);
+        assertEquals(Short.valueOf((short)0), deserialize.stringShortMap.get("first"));
+        assertEquals(Short.valueOf((short)60), deserialize.stringShortMap.get("last"));
+    }
+
+    @Test
+    public void serialize_string_byte_map_then_deserialize() throws Exception {
+
+        Hessian2StringShortType stringShort = new Hessian2StringShortType();
+        Map<String, Byte> stringByteMap = new HashMap<String, Byte>();
+        stringByteMap.put("first", (byte)0);
+        stringByteMap.put("last", (byte)60);
+        stringShort.stringByteMap = stringByteMap;
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        Hessian2Output out = new Hessian2Output(bout);
+
+        out.writeObject(stringShort);
+        out.flush();
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
+        Hessian2Input input = new Hessian2Input(bin);
+
+        Hessian2StringShortType deserialize = (Hessian2StringShortType) input.readObject();
+        assertTrue(deserialize.stringByteMap != null);
+        assertTrue(deserialize.stringByteMap.size() == 2);
+        assertTrue(deserialize.stringByteMap.get("last") instanceof Byte);
+        assertEquals(Byte.valueOf((byte)0), deserialize.stringByteMap.get("first"));
+        assertEquals(Byte.valueOf((byte) 60), deserialize.stringByteMap.get("last"));
+    }
+
+    @Test
+    public void serialize_map_then_deserialize() throws Exception {
+
+        Map<String, Short> stringShortMap = new HashMap<String, Short>();
+        stringShortMap.put("first", (short)0);
+        stringShortMap.put("last", (short)60);
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        Hessian2Output out = new Hessian2Output(bout);
+
+        out.writeObject(stringShortMap);
+        out.flush();
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
+        Hessian2Input input = new Hessian2Input(bin);
+        Map deserialize = (Map) input.readObject(HashMap.class, String.class, Short.class);
+        assertTrue(deserialize != null);
+        assertTrue(deserialize.size() == 2);
+        assertTrue(deserialize.get("last") instanceof Short);
+        assertEquals(Short.valueOf((short)0), deserialize.get("first"));
+        assertEquals(Short.valueOf((short)60), deserialize.get("last"));
+    }
+
+    @Test
+    public void serialize_string_person_map_then_deserialize() throws Exception {
+
+        Hessian2StringShortType stringShort = new Hessian2StringShortType();
+        Map<String, PersonType> stringPersonTypeMap = new HashMap<String, PersonType>();
+        stringPersonTypeMap.put("first", new PersonType(
+            "jason.shang", 26, (double) 0.1, (short)1, (byte)2, Arrays.asList((short)1,(short)1)
+        ));
+        stringPersonTypeMap.put("last", new PersonType(
+            "jason.shang2", 52, (double) 0.2, (short)2, (byte)4, Arrays.asList((short)2,(short)2)
+        ));
+        stringShort.stringPersonTypeMap = stringPersonTypeMap;
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        Hessian2Output out = new Hessian2Output(bout);
+
+        out.writeObject(stringShort);
+        out.flush();
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
+        Hessian2Input input = new Hessian2Input(bin);
+
+        Hessian2StringShortType deserialize = (Hessian2StringShortType) input.readObject();
+        assertTrue(deserialize.stringPersonTypeMap != null);
+        assertTrue(deserialize.stringPersonTypeMap.size() == 2);
+        assertTrue(deserialize.stringPersonTypeMap.get("last") instanceof PersonType);
+
+
+        assertEquals(new PersonType(
+            "jason.shang", 26, (double) 0.1, (short)1, (byte)2, Arrays.asList((short)1,(short)1)
+        ), deserialize.stringPersonTypeMap.get("first"));
+
+        assertEquals(new PersonType(
+            "jason.shang2", 52, (double) 0.2, (short)2, (byte)4, Arrays.asList((short)2,(short)2)
+        ), deserialize.stringPersonTypeMap.get("last"));
+
+    }
+
+    @Test
+    public void serialize_list_then_deserialize() throws Exception {
+
+        List<Short> shortList = new ArrayList<Short>();
+        shortList.add((short)0);
+        shortList.add((short)60);
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        Hessian2Output out = new Hessian2Output(bout);
+
+        out.writeObject(shortList);
+        out.flush();
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
+        Hessian2Input input = new Hessian2Input(bin);
+        List deserialize = (List) input.readObject(ArrayList.class, Short.class);
+//        List deserialize = (List) input.readObject();
+        assertTrue(deserialize != null);
+        assertTrue(deserialize.size() == 2);
+        assertTrue(deserialize.get(1) instanceof Short);
+        assertEquals(Short.valueOf((short)0), deserialize.get(0));
+        assertEquals(Short.valueOf((short)60), deserialize.get(1));
+    }
+
+}

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2StringShortType.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2StringShortType.java
@@ -1,0 +1,23 @@
+package com.alibaba.com.caucho.hessian.io;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ *
+ * test short serialize & deserialize model
+ *
+ * @author jason.shang
+ */
+public class Hessian2StringShortType implements Serializable {
+
+    Map<String, Short> stringShortMap;
+
+    Map<String, Byte> stringByteMap;
+
+    Map<String, PersonType> stringPersonTypeMap;
+
+    public Hessian2StringShortType(){
+
+    }
+}

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/PersonType.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/PersonType.java
@@ -1,8 +1,8 @@
 package com.alibaba.com.caucho.hessian.io;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * @author jason.shang
@@ -27,21 +27,32 @@ public class PersonType implements Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        PersonType type = (PersonType) o;
-        return age == type.age &&
-            Double.compare(type.money, money) == 0 &&
-            p1 == type.p1 &&
-            p2 == type.p2 &&
-            Objects.equals(name, type.name) &&
-            Objects.equals(p3, type.p3);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PersonType that = (PersonType) o;
+
+        if (age != that.age) return false;
+        if (Double.compare(that.money, money) != 0) return false;
+        if (p1 != that.p1) return false;
+        if (p2 != that.p2) return false;
+        if (!name.equals(that.name)) return false;
+        if (!p3.equals(that.p3)) return false;
+
+        return true;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, age, money, p1, p2, p3);
+        int result;
+        long temp;
+        result = name.hashCode();
+        result = 31 * result + age;
+        temp = Double.doubleToLongBits(money);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + (int) p1;
+        result = 31 * result + (int) p2;
+        result = 31 * result + p3.hashCode();
+        return result;
     }
 }

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/PersonType.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/PersonType.java
@@ -1,0 +1,47 @@
+package com.alibaba.com.caucho.hessian.io;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author jason.shang
+ */
+public class PersonType implements Serializable {
+
+    String name;
+    int age;
+    double money;
+    short p1;
+    byte  p2;
+    List<Short> p3;
+
+    public PersonType(String name, int age, double money, short p1, byte p2, List<Short> p3) {
+        this.name = name;
+        this.age = age;
+        this.money = money;
+        this.p1 = p1;
+        this.p2 = p2;
+        this.p3 = p3;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        PersonType type = (PersonType) o;
+        return age == type.age &&
+            Double.compare(type.money, money) == 0 &&
+            p1 == type.p1 &&
+            p2 == type.p2 &&
+            Objects.equals(name, type.name) &&
+            Objects.equals(p3, type.p3);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, age, money, p1, p2, p3);
+    }
+}


### PR DESCRIPTION
Fix hessian2 serialized short, byte is converted to int bug

for example:
 if we test deserialize mode 'Hessian2StringShortType'
`
public class Hessian2StringShortType implements Serializable {

    Map<String, Short> stringShortMap;

    Map<String, Byte> stringByteMap;

    Map<String, PersonType> stringPersonTypeMap;

    public Hessian2StringShortType(){

    }
}

public class PersonType implements Serializable {

    String name;
    int age;
    double money;
    short p1;
    byte  p2;
    List<Short> p3;

    public PersonType(String name, int age, double money, short p1, byte p2, List<Short> p3) {
        this.name = name;
        this.age = age;
        this.money = money;
        this.p1 = p1;
        this.p2 = p2;
        this.p3 = p3;
    }

    @Override
    public boolean equals(Object o) {
        if (this == o)
            return true;
        if (o == null || getClass() != o.getClass())
            return false;
        PersonType type = (PersonType) o;
        return age == type.age &&
            Double.compare(type.money, money) == 0 &&
            p1 == type.p1 &&
            p2 == type.p2 &&
            Objects.equals(name, type.name) &&
            Objects.equals(p3, type.p3);
    }

    @Override
    public int hashCode() {
        return Objects.hash(name, age, money, p1, p2, p3);
    }
}
`
`
    @Test
    public void serialize_string_short_map_then_deserialize() throws Exception {

        Hessian2StringShortType stringShort = new Hessian2StringShortType();
        Map<String, Short> stringShortMap = new HashMap<String, Short>();
        stringShortMap.put("first", (short)0);
        stringShortMap.put("last", (short)60);
        stringShort.stringShortMap = stringShortMap;

        ByteArrayOutputStream bout = new ByteArrayOutputStream();
        Hessian2Output out = new Hessian2Output(bout);

        out.writeObject(stringShort);
        out.flush();

        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
        Hessian2Input input = new Hessian2Input(bin);

        Hessian2StringShortType deserialize = (Hessian2StringShortType) input.readObject();
        assertTrue(deserialize.stringShortMap != null);
        assertTrue(deserialize.stringShortMap.size() == 2);
        // however, the deserialize result is Integer !!!
        assertTrue(deserialize.stringShortMap.get("last") instanceof Short);
        assertEquals(Short.valueOf((short)0), deserialize.stringShortMap.get("first"));
        assertEquals(Short.valueOf((short)60), deserialize.stringShortMap.get("last"));
    }
`
When we test serialize and deserialize 'Hessian2StringShortType', because it contains short、byte, 
the property stringShortMap will be deserialized Map<String, Integer>, not Map<String, Short>!!!

More detail unit test can see: `com.alibaba.com.caucho.hessian.io.Hessian2StringShortTest`

The problem has been fixed in the current branch, please verify and merge, Thank you.
Here is my email: shangzonghai@youzan.com or jason.shang@hotmail.com
 