### PR TITLE
[Dubbo-1279]Allow @Reference to support custom annotations

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/annotation/Reference.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/annotation/Reference.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface Reference {
 
     Class<?> interfaceClass() default void.class;


### PR DESCRIPTION
## What is the purpose of the change
Use custom annotations we can rename the annotation as more obvious name and add many default configs.
So I think support custom annotations is necessary.

Signed-off-by: Bo Cai charpty@gmail.com
请您查看: https://github.com/alibaba/dubbo/issues/1279

