### PR TITLE
Do not merge attachments when set attachments in RpcResult (#1166)

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcResult.java
@@ -95,10 +95,8 @@ public class RpcResult implements Result, Serializable {
         return attachments;
     }
 
-    public void setAttachments(Map<String, String> map) {
-        if (map != null && map.size() > 0) {
-            attachments.putAll(map);
-        }
+    public void setAttachments(Map<String, String> attachments) {
+        this.attachments = attachments == null ? new HashMap<String, String>() : attachments;
     }
 
     public String getAttachment(String key) {


### PR DESCRIPTION
Replace attachments in setAttachments of RpcResult, instead of merging the new attachments and old attachments. 

Closes #1166 