### PR TITLE
[Dubbo-1283] Ensure we can build Dubbo on Java 9 

### DIFF
--- a/dependencies-bom/pom.xml
+++ b/dependencies-bom/pom.xml
@@ -78,7 +78,7 @@
         <mina_version>1.1.7</mina_version>
         <grizzly_version>2.1.4</grizzly_version>
         <httpclient_version>4.5.3</httpclient_version>
-        <fastjson_version>1.2.31</fastjson_version>
+        <fastjson_version>1.2.46</fastjson_version>
         <zookeeper_version>3.4.9</zookeeper_version>
         <zkclient_version>0.2</zkclient_version>
         <curator_version>2.12.0</curator_version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ limitations under the License.
         <maven_compiler_version>3.6.0</maven_compiler_version>
         <maven_source_version>3.0.1</maven_source_version>
         <maven_cobertura_version>2.7</maven_cobertura_version>
-        <maven_javadoc_version>2.10.4</maven_javadoc_version>
+        <maven_javadoc_version>3.0.0</maven_javadoc_version>
         <maven_jetty_version>6.1.26</maven_jetty_version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,15 +168,6 @@ limitations under the License.
             </build>
         </profile>
         <profile>
-            <id>java8-doclint-disabled</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <javadoc.opts>-Xdoclint:none</javadoc.opts>
-            </properties>
-        </profile>
-        <profile>
             <id>java8-vm-args</id>
             <activation>
                 <jdk>[1.8,)</jdk>
@@ -229,7 +220,7 @@ limitations under the License.
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <additionalparam>${javadoc.opts}</additionalparam>
+                            <doclint>none</doclint>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## What is the purpose of the change

Fix #1283 Ensure we can build Dubbo on Java 9

## Brief changelog

1. Update maven-javadoc-plugin version
2. Disable doclint by default and adapt to new maven-javadoc-plugin format
3. Update fastjson version

## Verifying this change

- [x] Make sure there is a [GITHUB_issue](https://github.com/alibaba/dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
