### PR TITLE
[Dubbo-ci failed] fixed travis-ci failed because of test cases.

### DIFF
--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/java/com/alibaba/dubbo/rpc/protocol/thrift/AbstractTest.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/java/com/alibaba/dubbo/rpc/protocol/thrift/AbstractTest.java
@@ -18,6 +18,7 @@ package com.alibaba.dubbo.rpc.protocol.thrift;
 
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.common.extension.ExtensionLoader;
+import com.alibaba.dubbo.common.utils.NetUtils;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.Protocol;
 import com.alibaba.dubbo.rpc.gen.dubbo.$__DemoStub;
@@ -36,7 +37,7 @@ import org.junit.Before;
 
 public abstract class AbstractTest {
 
-    static final int PORT = 30660;
+    protected int PORT = NetUtils.getAvailablePort();
 
     protected TServer server;
 
@@ -44,8 +45,11 @@ public abstract class AbstractTest {
 
     protected Invoker<?> invoker;
 
+    TServerTransport serverTransport;
+
     protected void init() throws Exception {
-        TServerTransport serverTransport = new TServerSocket(PORT);
+
+        serverTransport = new TServerSocket(PORT);
 
         TBinaryProtocol.Factory bFactory = new TBinaryProtocol.Factory();
 
@@ -96,6 +100,15 @@ public abstract class AbstractTest {
         if (invoker != null) {
             invoker.destroy();
             invoker = null;
+        }
+
+        try{
+            if(serverTransport != null){
+                // release port if used
+                serverTransport.close();
+            }
+        }catch (Exception e) {
+            // ignore
         }
 
     }

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/java/com/alibaba/dubbo/rpc/protocol/thrift/ThriftProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/java/com/alibaba/dubbo/rpc/protocol/thrift/ThriftProtocolTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.dubbo.rpc.protocol.thrift;
 
 import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.utils.NetUtils;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.gen.dubbo.Demo;
 
@@ -25,7 +26,7 @@ import org.junit.Before;
 
 public class ThriftProtocolTest extends AbstractTest {
 
-    public static final int DEFAULT_PORT = 30660;
+    public final int DEFAULT_PORT = NetUtils.getAvailablePort();
 
     private ThriftProtocol protocol;
 


### PR DESCRIPTION
## What is the purpose of the change

fixed travis-ci failed because of test cases. see: com.alibaba.dubbo.rpc.protocol.thrift.AbstractTest

## Brief changelog
dubbo-rpc-thrift/src/test/java/com/alibaba/dubbo/rpc/protocol/thrift/AbstractTest.java
``` java
-    static final int PORT = 30660;
+    protected int PORT = NetUtils.getAvailablePort();

+    TServerTransport serverTransport;
+
     protected void init() throws Exception {
-        TServerTransport serverTransport = new TServerSocket(PORT);
+
+        serverTransport = new TServerSocket(PORT);

+        try{
+            if(serverTransport != null){
+                // release port if used
+                serverTransport.close();
+            }
+        }catch (Exception e) {
+            // ignore
+        }
```
## Verifying this change

should start ci test

Follow this checklist to help us incorporate your contribution quickly and easily:

- [] Make sure there is a [GITHUB_issue](https://github.com/alibaba/dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
