### PR TITLE
Remove redundant arguments for StatItem#isAllowable

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
@@ -40,7 +40,7 @@ public class DefaultTPSLimiter implements TPSLimiter {
                         new StatItem(serviceKey, rate, interval));
                 statItem = stats.get(serviceKey);
             }
-            return statItem.isAllowable(url, invocation);
+            return statItem.isAllowable();
         } else {
             StatItem statItem = stats.get(serviceKey);
             if (statItem != null) {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/tps/StatItem.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/tps/StatItem.java
@@ -16,9 +16,6 @@
  */
 package com.alibaba.dubbo.rpc.filter.tps;
 
-import com.alibaba.dubbo.common.URL;
-import com.alibaba.dubbo.rpc.Invocation;
-
 import java.util.concurrent.atomic.AtomicInteger;
 
 class StatItem {
@@ -41,7 +38,7 @@ class StatItem {
         this.token = new AtomicInteger(rate);
     }
 
-    public boolean isAllowable(URL url, Invocation invocation) {
+    public boolean isAllowable() {
         long now = System.currentTimeMillis();
         if (now > lastResetTime + interval) {
             token.set(rate);

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/tps/StatItemTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/tps/StatItemTest.java
@@ -16,10 +16,6 @@
  */
 package com.alibaba.dubbo.rpc.filter.tps;
 
-import com.alibaba.dubbo.common.URL;
-import com.alibaba.dubbo.rpc.Invocation;
-import com.alibaba.dubbo.rpc.RpcInvocation;
-
 import org.junit.After;
 import org.junit.Test;
 
@@ -30,10 +26,6 @@ public class StatItemTest {
 
     private StatItem statItem;
 
-    private URL url = URL.valueOf("test://localhost");
-
-    private Invocation invocation = new RpcInvocation();
-
     @After
     public void tearDown() throws Exception {
         statItem = null;
@@ -43,9 +35,9 @@ public class StatItemTest {
     public void testIsAllowable() throws Exception {
         statItem = new StatItem("test", 5, 1000L);
         long lastResetTime = statItem.getLastResetTime();
-        assertEquals(true, statItem.isAllowable(url, invocation));
+        assertEquals(true, statItem.isAllowable());
         Thread.sleep(1100L);
-        assertEquals(true, statItem.isAllowable(url, invocation));
+        assertEquals(true, statItem.isAllowable());
         assertTrue(lastResetTime != statItem.getLastResetTime());
         assertEquals(4, statItem.getToken());
     }


### PR DESCRIPTION
Currently, when we check if is allowable in ```StatItem```, we have two unnecessary arguments which are not used in the method. So we can remove them.