### PR TITLE
[fix] dubbo monitor parameter missing

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/MonitorConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/MonitorConfig.java
@@ -41,6 +41,8 @@ public class MonitorConfig extends AbstractConfig {
 
     private String version;
 
+    private String interval;
+
     // customized parameters
     private Map<String, String> parameters;
 
@@ -121,6 +123,14 @@ public class MonitorConfig extends AbstractConfig {
 
     public void setDefault(Boolean isDefault) {
         this.isDefault = isDefault;
+    }
+
+    public void setInterval(String interval){
+        this.interval = interval;
+    }
+
+    public String getInterval(){
+        return interval;
     }
 
 }

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -574,6 +574,11 @@
                 <xsd:documentation><![CDATA[ The monitor version. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="interval" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ The monitor interval. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="default" type="xsd:string" use="optional">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ Is default. ]]></xsd:documentation>

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/com/alibaba/dubbo/monitor/support/MonitorFilter.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/com/alibaba/dubbo/monitor/support/MonitorFilter.java
@@ -84,6 +84,8 @@ public class MonitorFilter implements Filter {
             String application = invoker.getUrl().getParameter(Constants.APPLICATION_KEY);
             String service = invoker.getInterface().getName(); // service name
             String method = RpcUtils.getMethodName(invocation); // method name
+            String group = invoker.getUrl().getParameter(Constants.GROUP_KEY);
+            String version = invoker.getUrl().getParameter(Constants.VERSION_KEY);
             URL url = invoker.getUrl().getUrlParameter(Constants.MONITOR_KEY);
             Monitor monitor = monitorFactory.getMonitor(url);
             if (monitor == null) {
@@ -121,7 +123,9 @@ public class MonitorFilter implements Filter {
                     MonitorService.ELAPSED, String.valueOf(elapsed),
                     MonitorService.CONCURRENT, String.valueOf(concurrent),
                     Constants.INPUT_KEY, input,
-                    Constants.OUTPUT_KEY, output));
+                    Constants.OUTPUT_KEY, output,
+                    Constants.GROUP_KEY, group,
+                    Constants.VERSION_KEY, version));
         } catch (Throwable t) {
             logger.error("Failed to monitor count service " + invoker.getUrl() + ", cause: " + t.getMessage(), t);
         }

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/com/alibaba/dubbo/monitor/dubbo/DubboMonitor.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/com/alibaba/dubbo/monitor/dubbo/DubboMonitor.java
@@ -16,6 +16,7 @@
  */
 package com.alibaba.dubbo.monitor.dubbo;
 
+import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.common.logger.Logger;
 import com.alibaba.dubbo.common.logger.LoggerFactory;
@@ -92,6 +93,7 @@ public class DubboMonitor implements Monitor {
             long maxOutput = numbers[7];
             long maxElapsed = numbers[8];
             long maxConcurrent = numbers[9];
+            String version = getUrl().getParameter(Constants.DEFAULT_PROTOCOL);
 
             // send statistics data
             URL url = statistics.getUrl()
@@ -105,7 +107,8 @@ public class DubboMonitor implements Monitor {
                             MonitorService.MAX_INPUT, String.valueOf(maxInput),
                             MonitorService.MAX_OUTPUT, String.valueOf(maxOutput),
                             MonitorService.MAX_ELAPSED, String.valueOf(maxElapsed),
-                            MonitorService.MAX_CONCURRENT, String.valueOf(maxConcurrent)
+                            MonitorService.MAX_CONCURRENT, String.valueOf(maxConcurrent),
+                            Constants.DEFAULT_PROTOCOL, version
                     );
             monitorService.collect(url);
 


### PR DESCRIPTION
2. monitor interval can be override by outside setting

## What is the purpose of the change

1.  dubbo monitor collection missing the `group` `version` `dubbo` parameters
2. dubbo monitor interval default set to 60s and can't override by outside setting

## Brief changelog

1. dubbo monitor parameters add `group`, `version`,`dubbo` parameters
2. monitor interval can be override by outside setting

## Verifying this change

XXXX
