### PR TITLE
add ASF license head

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,11 +1,12 @@
-Copyright 1999-2012 Alibaba Group.
- 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
- 
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,9 +47,9 @@ Mina:
 Grizzly:
 
   * LICENSE:
-    * http://www.gnu.org/licenses/gpl-2.0.html (General Public License 2.0)
+    * https://opensource.org/licenses/cddl-1.0 (CDDL 1.1)
   * HOMEPAGE:
-    * http://grizzly.java.net
+    * https://javaee.github.io/grizzly/
 
 HttpClient:
 
@@ -76,7 +77,7 @@ FastJson:
   * LICENSE:
     * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
   * HOMEPAGE:
-    * http://code.alibabatech.com/wiki/fastjson
+    * https://github.com/alibaba/fastjson
 
 Zookeeper:
 
@@ -88,9 +89,9 @@ Zookeeper:
 Jedis:
 
   * LICENSE:
-    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
+    * https://opensource.org/licenses/MIT (MIT)
   * HOMEPAGE:
-    * http://code.google.com/p/jedis
+    * https://github.com/xetorthio/jedis
 
 XMemcached:
 
@@ -141,6 +142,13 @@ JFreeChart:
   * HOMEPAGE:
     * http://www.jfree.org
 
+validation-api:
+
+  * LICENSE:
+    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
+  * HOMEPAGE:
+    *  http://beanvalidation.org
+
 HibernateValidator:
 
   * LICENSE:
@@ -168,3 +176,94 @@ Log4j:
     * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
   * HOMEPAGE:
     * http://log4j.apache.org
+
+Tomcat:
+
+  * LICENSE:
+    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
+  * HOMEPAGE:
+    * http://tomcat.apache.org
+
+cache-api:
+
+  * LICENSE:
+    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/jsr107/jsr107spec
+
+easymock
+
+  * LICENSE:
+    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
+  * HOMEPAGE:
+    * http://easymock.org
+
+cglib-nodep
+
+  * LICENSE:
+    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
+  * HOMEPAGE:
+    * https://sourceforge.net/projects/cglib/
+
+resteasy
+
+  * LICENSE:
+    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
+  * HOMEPAGE:
+    * http://resteasy.jboss.org/
+
+fst
+
+  * LICENSE:
+    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
+  * HOMEPAGE:
+    * http://ruedigermoeller.github.io/fast-serialization
+
+jmockit
+
+  * LICENSE:
+    * https://opensource.org/licenses/MIT (MIT)
+  * HOMEPAGE:
+    * http://www.jmockit.org
+
+jedis
+
+  * LICENSE:
+    * https://opensource.org/licenses/MIT (MIT)
+  * HOMEPAGE:
+    * http://www.jmockit.org
+
+javax.servlet-api:
+
+  * LICENSE:
+    * https://opensource.org/licenses/cddl-1.0 (CDDL 1.1)
+  * HOMEPAGE:
+    * http://servlet-spec.java.net
+
+javax.el:
+
+  * LICENSE:
+    * https://opensource.org/licenses/cddl-1.0 (CDDL 1.1)
+  * HOMEPAGE:
+    * https://javaee.github.io/uel-ri/
+
+logback-classic:
+
+  * LICENSE:
+    * http://www.eclipse.org/legal/epl-v10.html (EPL 1.0)
+  * HOMEPAGE:
+    * https://logback.qos.ch/
+
+junit:
+
+  * LICENSE:
+    * http://www.eclipse.org/legal/epl-v10.html (EPL 1.0)
+  * HOMEPAGE:
+    * http://www.junit.org
+
+kryo:
+
+  * LICENSE:
+    * https://opensource.org/licenses/BSD-3-Clause (BSD 3-clause)
+  * HOMEPAGE:
+    * https://github.com/EsotericSoftware/kryo

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/schema/AnnotationBeanDefinitionParser.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/schema/AnnotationBeanDefinitionParser.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.dubbo.config.spring.schema;
 
 import com.alibaba.dubbo.config.spring.AnnotationBean;
@@ -19,7 +35,6 @@ import static org.springframework.util.StringUtils.trimArrayElements;
 /**
  * {@link AnnotationBean} {@link BeanDefinitionParser}
  *
- * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see ServiceAnnotationBeanPostProcessor
  * @see ReferenceAnnotationBeanPostProcessor
  * @since 2.5.9

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/provider/DefaultHelloService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/context/annotation/provider/DefaultHelloService.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.dubbo.config.spring.context.annotation.provider;
 
 import com.alibaba.dubbo.config.spring.api.HelloService;
@@ -7,7 +23,6 @@ import org.springframework.stereotype.Service;
  * Default {@link HelloService} annotation with Spring's {@link Service}
  * and Dubbo's {@link com.alibaba.dubbo.config.annotation.Service}
  *
- * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since TODO
  */
 @Service

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-annotation-consumer.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-annotation-consumer.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- - Copyright 1999-2011 Alibaba Group.
- -
- - Licensed under the Apache License, Version 2.0 (the "License");
- - you may not use this file except in compliance with the License.
- - You may obtain a copy of the License at
- -
- -      http://www.apache.org/licenses/LICENSE-2.0
- -
- - Unless required by applicable law or agreed to in writing, software
- - distributed under the License is distributed on an "AS IS" BASIS,
- - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- - See the License for the specific language governing permissions and
- - limitations under the License.
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-annotation-provider.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-annotation-provider.xml
@@ -1,17 +1,18 @@
 <!--
- - Copyright 1999-2011 Alibaba Group.
- -
- - Licensed under the Apache License, Version 2.0 (the "License");
- - you may not use this file except in compliance with the License.
- - You may obtain a copy of the License at
- -
- -      http://www.apache.org/licenses/LICENSE-2.0
- -
- - Unless required by applicable law or agreed to in writing, software
- - distributed under the License is distributed on an "AS IS" BASIS,
- - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- - See the License for the specific language governing permissions and
- - limitations under the License.
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-consumer.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-consumer.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- - Copyright 1999-2011 Alibaba Group.
- -
- - Licensed under the Apache License, Version 2.0 (the "License");
- - you may not use this file except in compliance with the License.
- - You may obtain a copy of the License at
- -
- -      http://www.apache.org/licenses/LICENSE-2.0
- -
- - Unless required by applicable law or agreed to in writing, software
- - distributed under the License is distributed on an "AS IS" BASIS,
- - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- - See the License for the specific language governing permissions and
- - limitations under the License.
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-provider.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-provider.xml
@@ -1,17 +1,18 @@
 <!--
- - Copyright 1999-2011 Alibaba Group.
- -
- - Licensed under the Apache License, Version 2.0 (the "License");
- - you may not use this file except in compliance with the License.
- - You may obtain a copy of the License at
- -
- -      http://www.apache.org/licenses/LICENSE-2.0
- -
- - Unless required by applicable law or agreed to in writing, software
- - distributed under the License is distributed on an "AS IS" BASIS,
- - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- - See the License for the specific language governing permissions and
- - limitations under the License.
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/resources/dubbo-demo-consumer.xml
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/resources/dubbo-demo-consumer.xml
@@ -1,5 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
 
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"
        xmlns="http://www.springframework.org/schema/beans"

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/resources/dubbo-demo-provider.xml
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/resources/dubbo-demo-provider.xml
@@ -1,5 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
 
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"
        xmlns="http://www.springframework.org/schema/beans"

--- a/dubbo-test/dubbo-test-examples/src/main/java/com/alibaba/dubbo/examples/rest/rest-consumer.xml
+++ b/dubbo-test/dubbo-test-examples/src/main/java/com/alibaba/dubbo/examples/rest/rest-consumer.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"

--- a/dubbo-test/dubbo-test-examples/src/main/java/com/alibaba/dubbo/examples/rest/rest-provider.xml
+++ b/dubbo-test/dubbo-test-examples/src/main/java/com/alibaba/dubbo/examples/rest/rest-provider.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- - Copyright 1999-2011 Alibaba Group.
- -  
- - Licensed under the Apache License, Version 2.0 (the "License");
- - you may not use this file except in compliance with the License.
- - You may obtain a copy of the License at
- -  
- -      http://www.apache.org/licenses/LICENSE-2.0
- -  
- - Unless required by applicable law or agreed to in writing, software
- - distributed under the License is distributed on an "AS IS" BASIS,
- - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- - See the License for the specific language governing permissions and
- - limitations under the License.
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Deserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Deserializer.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 /**
  * Deserializing an object.
  *
- * @author jason.shang@hotmail.com
  */
 public interface Deserializer {
     public Class getType();

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/MapDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/MapDeserializer.java
@@ -100,7 +100,6 @@ public class MapDeserializer extends AbstractMapDeserializer {
      *  support generic type of map, fix the type of short serialization <p>
      *  eg: Map<String, Short> serialize & deserialize
      *
-     *  @author jason.shang@hotmail.com
      */
     @Override
     public Object readMap(AbstractHessianInput in, Class<?> expectKeyType, Class<?> expectValueType) throws IOException {

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/beans/BaseUser.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/beans/BaseUser.java
@@ -1,9 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.com.caucho.hessian.io.beans;
 
 import java.io.Serializable;
 
 /**
- * @author WangXin
  */
 public class BaseUser implements Serializable {
     private static final long serialVersionUID = 9104092580669691633L;

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/beans/GrandsonUser.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/beans/GrandsonUser.java
@@ -1,9 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.com.caucho.hessian.io.beans;
 
 import java.io.Serializable;
 
 /**
- * @author WangXin
  */
 public class GrandsonUser extends SubUser implements Serializable {
     private static final long serialVersionUID = 5013145666993778451L;


### PR DESCRIPTION
## What is the purpose of the change

add apache license

## Brief changelog
 
 Files that do not contain  `"Apache Software Foundation"` strings

## Verifying this change
 use `shell script`  to find files that do not contain  `"Apache Software Foundation"` strings：

```
cd dubbo
find . -type f -ctime 0| xargs grep -L "Apache Software Foundation"
```